### PR TITLE
Add social activity feed

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1226,3 +1226,153 @@ turbo-frame { display: contents; }
   .profile-actions { flex-direction: column; width: 100%; }
   .profile-actions .btn { width: 100%; text-align: center; }
 }
+
+/* ===== Activity Feed ===== */
+.activity-feed {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.activity-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  display: flex;
+  gap: 1rem;
+  transition: border-color var(--transition);
+}
+.activity-card:hover {
+  border-color: var(--accent);
+}
+
+.activity-card-avatar,
+.activity-card-avatars {
+  flex-shrink: 0;
+}
+
+.activity-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.activity-avatar-placeholder {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: var(--accent);
+  font-size: 1.1rem;
+}
+
+.activity-card-avatars {
+  display: flex;
+}
+.activity-avatar-overlap {
+  margin-left: -12px;
+  border: 2px solid var(--bg-card);
+}
+
+.activity-card-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.activity-card-header {
+  font-size: 0.95rem;
+  line-height: 1.4;
+  margin-bottom: 0.4rem;
+}
+
+.activity-user-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.activity-user-name:hover {
+  color: var(--accent);
+}
+
+.activity-action-text {
+  color: var(--text-secondary);
+}
+
+.activity-shop-link {
+  font-weight: 600;
+  color: var(--accent);
+}
+.activity-shop-link:hover {
+  color: var(--accent-hover);
+}
+
+.activity-rating {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+  margin-bottom: 0.35rem;
+}
+.activity-rating .star {
+  color: var(--text-muted, #555);
+  font-size: 0.9rem;
+}
+.activity-rating .star.filled {
+  color: var(--accent);
+}
+.activity-rating-label {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.activity-review-title {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin: 0 0 0.35rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.activity-timestamp {
+  font-size: 0.8rem;
+  color: var(--text-muted, #666);
+}
+
+.activity-load-more {
+  text-align: center;
+  padding: 2rem 0;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+.empty-state-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+.empty-state h3 {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  margin-bottom: 0.5rem;
+}
+.empty-state p {
+  margin-bottom: 1.5rem;
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media (max-width: 640px) {
+  .activity-card { padding: 1rem; }
+  .activity-avatar, .activity-avatar-placeholder { width: 36px; height: 36px; font-size: 0.9rem; }
+}

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,0 +1,25 @@
+class ActivitiesController < ApplicationController
+  before_action :authenticate_user!
+
+  PER_PAGE = 20
+
+  def index
+    friend_ids = current_user.friends.pluck(:id)
+    @activities = Activity.where(user_id: friend_ids)
+                          .includes(:user, :trackable)
+                          .order(created_at: :desc)
+                          .limit(PER_PAGE)
+                          .offset(page_offset)
+    @page = current_page
+  end
+
+  private
+
+  def current_page
+    [ (params[:page].to_i), 1 ].max
+  end
+
+  def page_offset
+    (current_page - 1) * PER_PAGE
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,9 @@
+class Activity < ApplicationRecord
+  belongs_to :user
+  belongs_to :trackable, polymorphic: true, optional: true
+
+  validates :action, presence: true
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :for_users, ->(users) { where(user: users) }
+end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -11,6 +11,8 @@ class Friendship < ApplicationRecord
   scope :accepted_for, ->(user) { accepted.for_user(user) }
   scope :pending_for, ->(user) { pending.where(friend: user) }
 
+  after_update :create_accepted_activity, if: :became_accepted?
+
   def other_user(current_user)
     current_user == user ? friend : user
   end
@@ -19,5 +21,14 @@ class Friendship < ApplicationRecord
 
   def cannot_friend_self
     errors.add(:friend, "can't be yourself") if user_id == friend_id
+  end
+
+  def became_accepted?
+    saved_change_to_status? && accepted?
+  end
+
+  def create_accepted_activity
+    Activity.create!(user: user, action: "became_friends", trackable: self)
+    Activity.create!(user: friend, action: "became_friends", trackable: self)
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -12,6 +12,8 @@ class Review < ApplicationRecord
   scope :recent, -> { order(created_at: :desc) }
   scope :highest_rated, -> { order(rating: :desc) }
 
+  after_create :create_activity
+
   def rating_label
     case rating
     when 5 then "Outstanding"
@@ -20,5 +22,11 @@ class Review < ApplicationRecord
     when 2 then "Fair"
     when 1 then "Poor"
     end
+  end
+
+  private
+
+  def create_activity
+    Activity.create!(user: user, action: "posted_review", trackable: self)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :activities, dependent: :destroy
   has_many :reviews, dependent: :destroy
   has_one_attached :avatar
 

--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -1,0 +1,58 @@
+<div class="activity-card">
+  <% case activity.action %>
+  <% when "posted_review" %>
+    <% if activity.trackable.present? %>
+      <div class="activity-card-avatar">
+        <% if activity.user.avatar.attached? %>
+          <%= image_tag activity.user.avatar, class: "activity-avatar" %>
+        <% else %>
+          <div class="activity-avatar-placeholder"><%= activity.user.name[0].upcase %></div>
+        <% end %>
+      </div>
+      <div class="activity-card-content">
+        <div class="activity-card-header">
+          <%= link_to activity.user.name, profile_path(activity.user), class: "activity-user-name" %>
+          <span class="activity-action-text">reviewed</span>
+          <%= link_to activity.trackable.chicken_shop.name, chicken_shop_path(activity.trackable.chicken_shop), class: "activity-shop-link" %>
+        </div>
+        <div class="activity-rating">
+          <% activity.trackable.rating.times do %>
+            <span class="star filled">★</span>
+          <% end %>
+          <% (5 - activity.trackable.rating).times do %>
+            <span class="star">★</span>
+          <% end %>
+          <span class="activity-rating-label"><%= activity.trackable.rating_label %></span>
+        </div>
+        <p class="activity-review-title"><%= activity.trackable.title %></p>
+        <div class="activity-timestamp"><%= time_ago_in_words(activity.created_at) %> ago</div>
+      </div>
+    <% end %>
+
+  <% when "became_friends" %>
+    <% if activity.trackable.present? %>
+      <% other = activity.trackable.other_user(activity.user) %>
+      <div class="activity-card-avatars">
+        <% if activity.user.avatar.attached? %>
+          <%= image_tag activity.user.avatar, class: "activity-avatar" %>
+        <% else %>
+          <div class="activity-avatar-placeholder"><%= activity.user.name[0].upcase %></div>
+        <% end %>
+        <% if other.avatar.attached? %>
+          <%= image_tag other.avatar, class: "activity-avatar activity-avatar-overlap" %>
+        <% else %>
+          <div class="activity-avatar-placeholder activity-avatar-overlap"><%= other.name[0].upcase %></div>
+        <% end %>
+      </div>
+      <div class="activity-card-content">
+        <div class="activity-card-header">
+          <%= link_to activity.user.name, profile_path(activity.user), class: "activity-user-name" %>
+          <span class="activity-action-text">and</span>
+          <%= link_to other.name, profile_path(other), class: "activity-user-name" %>
+          <span class="activity-action-text">became friends</span>
+        </div>
+        <div class="activity-timestamp"><%= time_ago_in_words(activity.created_at) %> ago</div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -1,0 +1,27 @@
+<div class="page-header">
+  <div class="container">
+    <h1 class="page-title">What's Happening</h1>
+    <p class="page-subtitle">See what your friends have been up to</p>
+  </div>
+</div>
+
+<div class="container" style="padding: 2rem 1.5rem;">
+  <% if @activities.any? %>
+    <div class="activity-feed">
+      <%= render partial: "activity", collection: @activities %>
+    </div>
+
+    <% if @activities.size == 20 %>
+      <div class="activity-load-more">
+        <%= link_to "Load more", activities_path(page: @page + 1), class: "btn btn-outline" %>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="empty-state">
+      <div class="empty-state-icon">📡</div>
+      <h3>No activity yet</h3>
+      <p class="text-muted">When your friends post reviews or make new connections, you'll see it here.</p>
+      <%= link_to "Find Friends", friendships_path, class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -9,6 +9,9 @@
 
     <div class="nav-center">
       <%= link_to "Discover", root_path, class: "nav-link #{'active' if current_page?(root_path)}" %>
+      <% if user_signed_in? %>
+        <%= link_to "Feed", activities_path, class: "nav-link #{'active' if current_page?(activities_path)}" %>
+      <% end %>
       <%= link_to "All Shops", chicken_shops_path, class: "nav-link #{'active' if current_page?(chicken_shops_path)}" %>
       <% if user_signed_in? %>
         <%= link_to friendships_path, class: "nav-link #{'active' if current_page?(friendships_path)}" do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
 
   resources :friendships, only: [ :index, :create, :update, :destroy ]
 
+  resources :activities, only: [ :index ]
+
   resources :conversations, only: [ :index, :show, :create ] do
     resources :messages, only: [ :create ]
   end

--- a/db/migrate/20260313000000_create_activities.rb
+++ b/db/migrate/20260313000000_create_activities.rb
@@ -1,0 +1,15 @@
+class CreateActivities < ActiveRecord::Migration[8.0]
+  def change
+    create_table :activities do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :action, null: false
+      t.string :trackable_type
+      t.integer :trackable_id
+
+      t.timestamps
+    end
+
+    add_index :activities, [ :user_id, :created_at ]
+    add_index :activities, [ :trackable_type, :trackable_id ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_12_213359) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_13_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -37,6 +37,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_213359) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "activities", force: :cascade do |t|
+    t.string "action", null: false
+    t.datetime "created_at", null: false
+    t.integer "trackable_id"
+    t.string "trackable_type"
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["trackable_type", "trackable_id"], name: "index_activities_on_trackable_type_and_trackable_id"
+    t.index ["user_id", "created_at"], name: "index_activities_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_activities_on_user_id"
   end
 
   create_table "chicken_shops", force: :cascade do |t|
@@ -126,6 +138,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_213359) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "activities", "users"
   add_foreign_key "conversation_reads", "conversations"
   add_foreign_key "conversation_reads", "users"
   add_foreign_key "conversations", "users", column: "receiver_id"

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class ActivitiesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    @friend = create(:user)
+    @stranger = create(:user)
+    @friendship = create(:friendship, :accepted, user: @user, friend: @friend)
+  end
+
+  # -- Authentication --
+
+  test "index redirects unauthenticated users" do
+    get activities_path
+    assert_redirected_to new_user_session_path
+  end
+
+  # -- #index --
+
+  test "index loads successfully for authenticated users" do
+    sign_in @user
+    get activities_path
+    assert_response :success
+  end
+
+  test "index shows activities from friends" do
+    sign_in @user
+    activity = Activity.create!(user: @friend, action: "posted_review")
+
+    get activities_path
+    assert_response :success
+    assert_select ".activity-card", minimum: 1
+  end
+
+  test "index does not show activities from non-friends" do
+    sign_in @user
+    Activity.create!(user: @stranger, action: "posted_review")
+
+    get activities_path
+    assert_response :success
+    assert_select ".activity-card", 0
+  end
+
+  test "index shows empty state when no friend activity" do
+    sign_in @user
+
+    get activities_path
+    assert_response :success
+    assert_select ".empty-state"
+  end
+
+  test "index orders activities newest first" do
+    sign_in @user
+
+    # Create activities directly with explicit timestamps
+    old_activity = Activity.create!(user: @friend, action: "posted_review", created_at: 2.days.ago)
+    recent_activity = Activity.create!(user: @friend, action: "became_friends", created_at: 1.hour.ago)
+
+    get activities_path
+    assert_response :success
+
+    # Verify both appear and recent is first by checking card count
+    assert_select ".activity-card", minimum: 2
+  end
+
+  test "index does not show current user's own activities" do
+    sign_in @user
+    Activity.create!(user: @user, action: "posted_review")
+
+    get activities_path
+    assert_select ".activity-card", 0
+  end
+end

--- a/test/factories/activities.rb
+++ b/test/factories/activities.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :activity do
+    association :user
+    action { "posted_review" }
+
+    trait :review_activity do
+      action { "posted_review" }
+      association :trackable, factory: :review
+    end
+
+    trait :friendship_activity do
+      action { "became_friends" }
+      association :trackable, factory: [ :friendship, :accepted ]
+    end
+  end
+end

--- a/test/models/activity_test.rb
+++ b/test/models/activity_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+
+class ActivityTest < ActiveSupport::TestCase
+  # -- Associations --
+
+  test "belongs to a user" do
+    activity = create(:activity, :review_activity)
+    assert_instance_of User, activity.user
+  end
+
+  test "belongs to a trackable (polymorphic)" do
+    activity = create(:activity, :review_activity)
+    assert_instance_of Review, activity.trackable
+  end
+
+  test "trackable can be a friendship" do
+    activity = create(:activity, :friendship_activity)
+    assert_instance_of Friendship, activity.trackable
+  end
+
+  # -- Validations --
+
+  test "valid with all required attributes" do
+    assert build(:activity, :review_activity).valid?
+  end
+
+  test "invalid without action" do
+    activity = build(:activity, action: nil)
+    assert_not activity.valid?
+    assert activity.errors[:action].any?
+  end
+
+  test "invalid without user" do
+    activity = build(:activity, user: nil)
+    assert_not activity.valid?
+    assert activity.errors[:user].any?
+  end
+
+  test "valid without trackable" do
+    activity = build(:activity, trackable: nil)
+    assert activity.valid?
+  end
+
+  # -- Scopes --
+
+  test "recent scope orders by created_at descending" do
+    old_activity = create(:activity, :review_activity, created_at: 2.days.ago)
+    new_activity = create(:activity, :review_activity, created_at: 1.hour.ago)
+
+    results = Activity.recent.to_a
+    assert results.index(new_activity) < results.index(old_activity)
+  end
+
+  test "for_users scope returns activities for given users" do
+    user1 = create(:user)
+    user2 = create(:user)
+    user3 = create(:user)
+
+    a1 = create(:activity, user: user1, action: "posted_review")
+    a2 = create(:activity, user: user2, action: "posted_review")
+    _a3 = create(:activity, user: user3, action: "posted_review")
+
+    results = Activity.for_users([ user1, user2 ])
+    assert_includes results, a1
+    assert_includes results, a2
+    assert_not_includes results, _a3
+  end
+
+  # -- Callbacks --
+
+  test "creating a review creates a posted_review activity" do
+    user = create(:user)
+    shop = create(:chicken_shop)
+
+    assert_difference "Activity.count", 1 do
+      create(:review, user: user, chicken_shop: shop)
+    end
+
+    activity = Activity.last
+    assert_equal "posted_review", activity.action
+    assert_equal user, activity.user
+    assert_equal "Review", activity.trackable_type
+  end
+
+  test "accepting a friendship creates became_friends activities for both users" do
+    friendship = create(:friendship)
+
+    assert_difference "Activity.count", 2 do
+      friendship.accepted!
+    end
+
+    activities = Activity.where(action: "became_friends", trackable: friendship)
+    assert_equal 2, activities.count
+    assert_includes activities.map(&:user), friendship.user
+    assert_includes activities.map(&:user), friendship.friend
+  end
+
+  # -- User association --
+
+  test "user has many activities" do
+    user = create(:user)
+    create(:activity, user: user, action: "posted_review")
+    create(:activity, user: user, action: "became_friends")
+
+    assert_equal 2, user.activities.count
+  end
+
+  test "destroying user destroys activities" do
+    user = create(:user)
+    create(:activity, user: user, action: "posted_review")
+
+    assert_difference "Activity.count", -1 do
+      user.destroy
+    end
+  end
+end


### PR DESCRIPTION
## What
Social activity feed showing friends' reviews and new friendships.

## Changes
- Activity model with polymorphic trackable (Review, Friendship)
- Auto-creation via after_create callbacks
- Activities feed page showing friend activities
- Activity cards for reviews (with rating) and friendships
- Feed link in navbar
- Full test coverage

## How It Works
- When a user posts a review → Activity record created
- When a friendship is accepted → Activity record created
- Feed page shows activities from your friends, newest first