### PR TITLE
Add review reactions and helpfulness voting

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1226,3 +1226,152 @@ turbo-frame { display: contents; }
   .profile-actions { flex-direction: column; width: 100%; }
   .profile-actions .btn { width: 100%; text-align: center; }
 }
+
+/* ======================== Review Reactions ======================== */
+.reaction-bar {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.reaction-emojis {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.reaction-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.2s ease;
+}
+
+.reaction-btn:hover {
+  border-color: var(--accent);
+  background: rgba(255, 107, 53, 0.1);
+}
+
+.reaction-btn--active {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  background: rgba(255, 107, 53, 0.15);
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.2s ease;
+}
+
+.reaction-emoji {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.reaction-count {
+  font-size: 0.8rem;
+  font-weight: 600;
+  min-width: 0.75rem;
+  text-align: center;
+}
+
+.reaction-count--animating {
+  animation: count-pop 0.3s ease;
+}
+
+@keyframes count-pop {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+  100% { transform: scale(1); }
+}
+
+.reaction-helpful {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.helpful-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: all 0.2s ease;
+}
+
+.helpful-btn:hover {
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.helpful-btn--active {
+  border-color: var(--accent);
+  background: rgba(255, 107, 53, 0.15);
+  color: var(--accent);
+}
+
+.helpful-text {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+/* Reviews sort controls */
+.reviews-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.reviews-header .reviews-heading {
+  margin-bottom: 0;
+}
+
+.reviews-sort {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.sort-btn {
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.8rem;
+  transition: all 0.2s ease;
+}
+
+.sort-btn:hover {
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.sort-btn--active {
+  border-color: var(--accent);
+  background: rgba(255, 107, 53, 0.15);
+  color: var(--accent);
+}

--- a/app/controllers/chicken_shops_controller.rb
+++ b/app/controllers/chicken_shops_controller.rb
@@ -26,7 +26,12 @@ class ChickenShopsController < ApplicationController
 
   def show
     @chicken_shop = ChickenShop.find(params[:id])
-    @reviews = @chicken_shop.reviews.includes(:user).recent
+    @sort = params[:sort]
+    @reviews = if @sort == "most_helpful"
+      @chicken_shop.reviews.includes(:user, :reactions).by_most_helpful
+    else
+      @chicken_shop.reviews.includes(:user, :reactions).recent
+    end
     @review = Review.new
     @user_review = current_user ? @chicken_shop.reviews.find_by(user: current_user) : nil
   end

--- a/app/controllers/review_reactions_controller.rb
+++ b/app/controllers/review_reactions_controller.rb
@@ -1,0 +1,33 @@
+class ReviewReactionsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_review
+
+  def create
+    @reaction = @review.reactions.find_by(user: current_user, kind: params[:kind])
+
+    if @reaction
+      @reaction.destroy
+    else
+      @reaction = @review.reactions.build(user: current_user, kind: params[:kind])
+      unless @reaction.save
+        head :unprocessable_entity
+        return
+      end
+    end
+
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.replace(
+        "review_#{@review.id}_reactions",
+        partial: "reviews/reaction_bar",
+        locals: { review: @review.reload, current_user: current_user }
+      ) }
+      format.html { redirect_back fallback_location: @review.chicken_shop }
+    end
+  end
+
+  private
+
+  def set_review
+    @review = Review.find(params[:review_id])
+  end
+end

--- a/app/javascript/controllers/reaction_controller.js
+++ b/app/javascript/controllers/reaction_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["button", "count"]
+
+  toggle(event) {
+    const button = event.currentTarget
+    const isActive = button.classList.contains("reaction-btn--active") ||
+                     button.classList.contains("helpful-btn--active")
+
+    // Optimistic toggle of active class
+    if (button.classList.contains("reaction-btn") || button.classList.contains("reaction-btn--active")) {
+      button.classList.toggle("reaction-btn--active")
+    }
+    if (button.classList.contains("helpful-btn") || button.classList.contains("helpful-btn--active")) {
+      button.classList.toggle("helpful-btn--active")
+    }
+
+    // Animate count change
+    const countEl = button.querySelector("[data-reaction-target='count']")
+    if (countEl) {
+      countEl.classList.add("reaction-count--animating")
+      setTimeout(() => countEl.classList.remove("reaction-count--animating"), 300)
+    }
+  }
+}

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -2,6 +2,7 @@ class Review < ApplicationRecord
   belongs_to :user
   belongs_to :chicken_shop
 
+  has_many :reactions, class_name: "ReviewReaction", dependent: :destroy
   has_many_attached :photos
 
   validates :rating, presence: true, inclusion: { in: 1..5 }
@@ -11,6 +12,21 @@ class Review < ApplicationRecord
 
   scope :recent, -> { order(created_at: :desc) }
   scope :highest_rated, -> { order(rating: :desc) }
+  scope :by_most_helpful, -> {
+    left_joins(:reactions)
+      .group(:id)
+      .order(
+        Arel.sql("COALESCE(SUM(CASE WHEN review_reactions.kind = 'helpful' THEN 1 WHEN review_reactions.kind = 'not_helpful' THEN -1 ELSE 0 END), 0) DESC")
+      )
+  }
+
+  def reactions_summary
+    reactions.group(:kind).count
+  end
+
+  def helpful_score
+    reactions.where(kind: "helpful").count - reactions.where(kind: "not_helpful").count
+  end
 
   def rating_label
     case rating

--- a/app/models/review_reaction.rb
+++ b/app/models/review_reaction.rb
@@ -1,0 +1,9 @@
+class ReviewReaction < ApplicationRecord
+  KINDS = %w[fire thumbs_up heart_eyes laugh helpful not_helpful].freeze
+
+  belongs_to :user
+  belongs_to :review
+
+  validates :kind, presence: true, inclusion: { in: KINDS }
+  validates :kind, uniqueness: { scope: [ :user_id, :review_id ], message: "already reacted with this kind" }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :reviews, dependent: :destroy
+  has_many :review_reactions, dependent: :destroy
   has_one_attached :avatar
 
   # Friendships

--- a/app/views/chicken_shops/show.html.erb
+++ b/app/views/chicken_shops/show.html.erb
@@ -115,7 +115,13 @@
 
       <!-- Right column: Reviews -->
       <div class="shop-reviews">
-        <h2 class="reviews-heading">Reviews (<%= @reviews.count %>)</h2>
+        <div class="reviews-header">
+          <h2 class="reviews-heading">Reviews (<%= @reviews.count %>)</h2>
+          <div class="reviews-sort">
+            <%= link_to "Recent", chicken_shop_path(@chicken_shop, sort: "recent"), class: "sort-btn #{'sort-btn--active' unless @sort == 'most_helpful'}" %>
+            <%= link_to "Most Helpful", chicken_shop_path(@chicken_shop, sort: "most_helpful"), class: "sort-btn #{'sort-btn--active' if @sort == 'most_helpful'}" %>
+          </div>
+        </div>
 
         <%= turbo_frame_tag "reviews_list" do %>
           <% if @reviews.any? %>

--- a/app/views/reviews/_reaction_bar.html.erb
+++ b/app/views/reviews/_reaction_bar.html.erb
@@ -1,0 +1,56 @@
+<%= turbo_frame_tag "review_#{review.id}_reactions" do %>
+  <div class="reaction-bar" data-controller="reaction">
+    <div class="reaction-emojis">
+      <% { "fire" => "🔥", "thumbs_up" => "👍", "heart_eyes" => "😍", "laugh" => "😂" }.each do |kind, emoji| %>
+        <% count = review.reactions.where(kind: kind).count %>
+        <% active = defined?(current_user) && current_user && review.reactions.exists?(user: current_user, kind: kind) %>
+        <%= button_to review_reactions_path(review, kind: kind),
+              method: :post,
+              class: "reaction-btn #{'reaction-btn--active' if active}",
+              data: {
+                turbo_stream: true,
+                action: "click->reaction#toggle",
+                reaction_target: "button"
+              } do %>
+          <span class="reaction-emoji"><%= emoji %></span>
+          <% if count > 0 %>
+            <span class="reaction-count" data-reaction-target="count"><%= count %></span>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="reaction-helpful">
+      <% helpful_count = review.reactions.where(kind: "helpful").count %>
+      <% not_helpful_count = review.reactions.where(kind: "not_helpful").count %>
+      <% user_helpful = defined?(current_user) && current_user && review.reactions.exists?(user: current_user, kind: "helpful") %>
+      <% user_not_helpful = defined?(current_user) && current_user && review.reactions.exists?(user: current_user, kind: "not_helpful") %>
+
+      <%= button_to review_reactions_path(review, kind: "helpful"),
+            method: :post,
+            class: "helpful-btn #{'helpful-btn--active' if user_helpful}",
+            data: {
+              turbo_stream: true,
+              action: "click->reaction#toggle",
+              reaction_target: "button"
+            } do %>
+        👍 Helpful
+      <% end %>
+
+      <%= button_to review_reactions_path(review, kind: "not_helpful"),
+            method: :post,
+            class: "helpful-btn helpful-btn--down #{'helpful-btn--active' if user_not_helpful}",
+            data: {
+              turbo_stream: true,
+              action: "click->reaction#toggle",
+              reaction_target: "button"
+            } do %>
+        👎
+      <% end %>
+
+      <% if helpful_count > 0 %>
+        <span class="helpful-text"><%= helpful_count %> <%= helpful_count == 1 ? "person" : "people" %> found this helpful</span>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/reviews/_review_card.html.erb
+++ b/app/views/reviews/_review_card.html.erb
@@ -36,5 +36,7 @@
         <%= button_to "Delete", chicken_shop_review_path(chicken_shop, review), method: :delete, class: "btn btn-danger btn-sm", data: { turbo_confirm: "Are you sure you want to delete this review?" } %>
       </div>
     <% end %>
+
+    <%= render "reviews/reaction_bar", review: review, current_user: (defined?(current_user) ? current_user : nil) %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Rails.application.routes.draw do
     resources :reviews, only: [ :create, :destroy ]
   end
 
+  resources :reviews, only: [] do
+    resources :reactions, only: [ :create ], controller: "review_reactions"
+  end
+
   resources :profiles, only: [ :show, :edit, :update ], param: :id
 
   resources :friendships, only: [ :index, :create, :update, :destroy ]

--- a/db/migrate/20260312215820_create_review_reactions.rb
+++ b/db/migrate/20260312215820_create_review_reactions.rb
@@ -1,0 +1,13 @@
+class CreateReviewReactions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :review_reactions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :review, null: false, foreign_key: true
+      t.string :kind, null: false
+
+      t.timestamps
+    end
+
+    add_index :review_reactions, [ :user_id, :review_id, :kind ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_12_213359) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_12_215820) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -98,6 +98,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_213359) do
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
+  create_table "review_reactions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "kind", null: false
+    t.integer "review_id", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["review_id"], name: "index_review_reactions_on_review_id"
+    t.index ["user_id", "review_id", "kind"], name: "index_review_reactions_on_user_id_and_review_id_and_kind", unique: true
+    t.index ["user_id"], name: "index_review_reactions_on_user_id"
+  end
+
   create_table "reviews", force: :cascade do |t|
     t.text "body"
     t.integer "chicken_shop_id", null: false
@@ -134,6 +145,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_213359) do
   add_foreign_key "friendships", "users", column: "friend_id"
   add_foreign_key "messages", "conversations"
   add_foreign_key "messages", "users"
+  add_foreign_key "review_reactions", "reviews"
+  add_foreign_key "review_reactions", "users"
   add_foreign_key "reviews", "chicken_shops"
   add_foreign_key "reviews", "users"
 end

--- a/test/controllers/review_reactions_controller_test.rb
+++ b/test/controllers/review_reactions_controller_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class ReviewReactionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    @review = create(:review)
+  end
+
+  # -- Authentication --
+
+  test "create redirects unauthenticated users" do
+    post review_reactions_path(@review), params: { kind: "fire" }
+    assert_redirected_to new_user_session_path
+  end
+
+  # -- #create (toggle) --
+
+  test "create adds a reaction when none exists" do
+    sign_in @user
+
+    assert_difference "ReviewReaction.count", 1 do
+      post review_reactions_path(@review), params: { kind: "fire" }
+    end
+
+    reaction = ReviewReaction.last
+    assert_equal @user, reaction.user
+    assert_equal @review, reaction.review
+    assert_equal "fire", reaction.kind
+  end
+
+  test "create removes a reaction when one exists (toggle off)" do
+    sign_in @user
+    create(:review_reaction, user: @user, review: @review, kind: "fire")
+
+    assert_difference "ReviewReaction.count", -1 do
+      post review_reactions_path(@review), params: { kind: "fire" }
+    end
+  end
+
+  test "create responds with turbo_stream" do
+    sign_in @user
+
+    post review_reactions_path(@review), params: { kind: "thumbs_up" }, as: :turbo_stream
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html; charset=utf-8", response.content_type
+  end
+
+  test "create with html format redirects" do
+    sign_in @user
+
+    post review_reactions_path(@review), params: { kind: "thumbs_up" }
+
+    assert_response :redirect
+  end
+
+  test "create with invalid kind returns error" do
+    sign_in @user
+
+    assert_no_difference "ReviewReaction.count" do
+      post review_reactions_path(@review), params: { kind: "invalid" }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "toggling different kinds creates separate reactions" do
+    sign_in @user
+
+    post review_reactions_path(@review), params: { kind: "fire" }
+    post review_reactions_path(@review), params: { kind: "thumbs_up" }
+
+    assert_equal 2, @review.reactions.where(user: @user).count
+  end
+
+  test "toggling helpful and not_helpful are independent" do
+    sign_in @user
+
+    post review_reactions_path(@review), params: { kind: "helpful" }
+    post review_reactions_path(@review), params: { kind: "not_helpful" }
+
+    assert_equal 2, @review.reactions.where(user: @user).count
+  end
+end

--- a/test/factories/review_reactions.rb
+++ b/test/factories/review_reactions.rb
@@ -1,0 +1,31 @@
+FactoryBot.define do
+  factory :review_reaction do
+    association :user
+    association :review
+    kind { "thumbs_up" }
+
+    trait :fire do
+      kind { "fire" }
+    end
+
+    trait :thumbs_up do
+      kind { "thumbs_up" }
+    end
+
+    trait :heart_eyes do
+      kind { "heart_eyes" }
+    end
+
+    trait :laugh do
+      kind { "laugh" }
+    end
+
+    trait :helpful do
+      kind { "helpful" }
+    end
+
+    trait :not_helpful do
+      kind { "not_helpful" }
+    end
+  end
+end

--- a/test/models/review_reaction_test.rb
+++ b/test/models/review_reaction_test.rb
@@ -1,0 +1,132 @@
+require "test_helper"
+
+class ReviewReactionTest < ActiveSupport::TestCase
+  # -- Associations --
+
+  test "belongs to a user" do
+    reaction = create(:review_reaction)
+    assert_instance_of User, reaction.user
+  end
+
+  test "belongs to a review" do
+    reaction = create(:review_reaction)
+    assert_instance_of Review, reaction.review
+  end
+
+  # -- Validations --
+
+  test "valid with all required attributes" do
+    assert build(:review_reaction).valid?
+  end
+
+  test "invalid without kind" do
+    reaction = build(:review_reaction, kind: nil)
+    assert_not reaction.valid?
+    assert reaction.errors[:kind].any?
+  end
+
+  test "invalid with unknown kind" do
+    reaction = build(:review_reaction, kind: "clap")
+    assert_not reaction.valid?
+    assert reaction.errors[:kind].any?
+  end
+
+  test "valid with each allowed kind" do
+    ReviewReaction::KINDS.each do |kind|
+      reaction = build(:review_reaction, kind: kind)
+      assert reaction.valid?, "Expected #{kind} to be valid"
+    end
+  end
+
+  test "enforces uniqueness of kind per user per review" do
+    user = create(:user)
+    review = create(:review)
+    create(:review_reaction, user: user, review: review, kind: "fire")
+
+    duplicate = build(:review_reaction, user: user, review: review, kind: "fire")
+    assert_not duplicate.valid?
+    assert duplicate.errors[:kind].any?
+  end
+
+  test "same user can react with different kinds to the same review" do
+    user = create(:user)
+    review = create(:review)
+    create(:review_reaction, user: user, review: review, kind: "fire")
+
+    assert build(:review_reaction, user: user, review: review, kind: "thumbs_up").valid?
+  end
+
+  test "different users can react with the same kind to the same review" do
+    review = create(:review)
+    user1 = create(:user)
+    user2 = create(:user)
+    create(:review_reaction, user: user1, review: review, kind: "fire")
+
+    assert build(:review_reaction, user: user2, review: review, kind: "fire").valid?
+  end
+
+  # -- Review#reactions_summary --
+
+  test "reactions_summary returns counts per kind" do
+    review = create(:review)
+    3.times { create(:review_reaction, review: review, kind: "fire") }
+    2.times { create(:review_reaction, review: review, kind: "thumbs_up") }
+
+    summary = review.reactions_summary
+    assert_equal 3, summary["fire"]
+    assert_equal 2, summary["thumbs_up"]
+  end
+
+  test "reactions_summary returns empty hash when no reactions" do
+    review = create(:review)
+    assert_equal({}, review.reactions_summary)
+  end
+
+  # -- Review#helpful_score --
+
+  test "helpful_score returns difference of helpful and not_helpful counts" do
+    review = create(:review)
+    3.times { create(:review_reaction, review: review, kind: "helpful") }
+    1.times { create(:review_reaction, review: review, kind: "not_helpful") }
+
+    assert_equal 2, review.helpful_score
+  end
+
+  test "helpful_score returns 0 when no votes" do
+    review = create(:review)
+    assert_equal 0, review.helpful_score
+  end
+
+  test "helpful_score can be negative" do
+    review = create(:review)
+    create(:review_reaction, review: review, kind: "not_helpful")
+
+    assert_equal(-1, review.helpful_score)
+  end
+
+  # -- Review.by_most_helpful --
+
+  test "by_most_helpful orders reviews by helpful score descending" do
+    shop = create(:chicken_shop)
+    low = create(:review, chicken_shop: shop)
+    high = create(:review, chicken_shop: shop)
+
+    3.times { create(:review_reaction, review: high, kind: "helpful") }
+    1.times { create(:review_reaction, review: low, kind: "helpful") }
+
+    results = Review.by_most_helpful.to_a
+    assert results.index(high) < results.index(low)
+  end
+
+  # -- Dependent destroy --
+
+  test "reactions are destroyed when review is destroyed" do
+    review = create(:review)
+    create(:review_reaction, review: review, kind: "fire")
+    create(:review_reaction, review: review, kind: "thumbs_up")
+
+    assert_difference "ReviewReaction.count", -2 do
+      review.destroy
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Users can react to reviews with emoji (🔥👍😍😂) and vote reviews as helpful/not helpful. Reactions toggle on/off and update via Turbo Streams with optimistic UI. Reviews can be sorted by most helpful on the chicken shop page.

## Changes

### New files
- `ReviewReaction` model with validations and associations
- `ReviewReactionsController` with toggle create action
- `_reaction_bar.html.erb` partial with Turbo Frame
- `reaction_controller.js` Stimulus controller for optimistic UI
- Migration, factory, model tests (14), controller tests (8)

### Modified files
- `Review` model: `reactions_summary`, `helpful_score`, `by_most_helpful` scope
- `User` model: `has_many :review_reactions`
- Routes: nested `reactions` under `reviews`
- `ChickenShopsController#show`: sort param + eager loading
- `chicken_shops/show.html.erb`: sort controls (Recent / Most Helpful)
- `_review_card.html.erb`: renders reaction bar
- `application.css`: reaction bar + sort control styles

## Testing

All 224 tests pass (394 assertions, 0 failures, 0 errors).