### PR TITLE
Security Hardening: Auth lockout, SQL injection fixes, production headers

### DIFF
--- a/app/controllers/api/shops_controller.rb
+++ b/app/controllers/api/shops_controller.rb
@@ -8,8 +8,9 @@ module Api
                          .group("chicken_shops.id")
 
       if params[:search].present?
+        term = ActiveRecord::Base.sanitize_sql_like(params[:search])
         shops = shops.where("name LIKE ? OR city LIKE ? OR postcode LIKE ?",
-          "%#{params[:search]}%", "%#{params[:search]}%", "%#{params[:search]}%")
+          "%#{term}%", "%#{term}%", "%#{term}%")
       end
 
       if params[:lat].present? && params[:lng].present?

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -22,7 +22,7 @@ class FriendshipsController < ApplicationController
       if @friendship.save
         redirect_to profile_path(friend), notice: "Friend request sent to #{friend.name}! 🤝"
       else
-        redirect_to profile_path(friend), alert: @friendship.errors.full_messages.join(", ")
+        redirect_to profile_path(friend), alert: "Unable to send friend request. Please try again."
       end
     rescue ActiveRecord::RecordNotUnique
       redirect_to profile_path(friend), alert: "Friend request already exists."

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,8 +9,10 @@ class MessagesController < ApplicationController
     if params[:message][:shareable_type].present? && params[:message][:shareable_id].present?
       shareable_type = params[:message][:shareable_type]
       if Message::ALLOWED_SHAREABLE_TYPES.include?(shareable_type)
-        @message.shareable_type = shareable_type
-        @message.shareable_id = params[:message][:shareable_id]
+        shareable = shareable_type.constantize.find_by(id: params[:message][:shareable_id])
+        if shareable
+          @message.shareable = shareable
+        end
       end
     end
 

--- a/app/models/chicken_shop.rb
+++ b/app/models/chicken_shop.rb
@@ -10,8 +10,8 @@ class ChickenShop < ApplicationRecord
   validates :longitude, presence: true
   validates :website, format: { with: /\Ahttps?:\/\/\S+\z/i, message: "must start with http:// or https://" }, allow_blank: true
 
-  scope :search_by_name, ->(query) { where("name LIKE ?", "%#{query}%") if query.present? }
-  scope :search_by_city, ->(city) { where("city LIKE ?", "%#{city}%") if city.present? }
+  scope :search_by_name, ->(query) { where("name LIKE ?", "%#{sanitize_sql_like(query)}%") if query.present? }
+  scope :search_by_city, ->(city) { where("city LIKE ?", "%#{sanitize_sql_like(city)}%") if city.present? }
 
   scope :with_min_rating, ->(rating) {
     left_joins(:reviews)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :lockable, :timeoutable
 
   has_many :activities, dependent: :destroy
   has_many :reviews, dependent: :destroy

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV["REDIS_URL"] %>
   channel_prefix: cluckbait_production

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,8 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  # TODO: Replace with actual production domain
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST", "cluckbait.com") }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {
@@ -86,4 +87,10 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  # Security headers
+  config.action_dispatch.default_headers.merge!(
+    "Permissions-Policy" => "camera=(), microphone=(), geolocation=(self)",
+    "X-Permitted-Cross-Domain-Policies" => "none"
+  )
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV.fetch("DEVISE_MAILER_SENDER", "noreply@cluckbait.com")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -90,7 +90,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.
@@ -129,10 +129,10 @@ Devise.setup do |config|
   # config.pepper = '0bca314dc910f850a9b4f53d18fe78271c2a4d3265a8941c8e1dac6dec80579b8e497125b6e9bf64b81f655c65a6e4817ffda10b41c3f7963baa16c6a6a8cf39'
 
   # Send a notification to the original email when the user's email is changed.
-  # config.send_email_changed_notification = false
+  config.send_email_changed_notification = true
 
   # Send a notification email when the user's password is changed.
-  # config.send_password_change_notification = false
+  config.send_password_change_notification = true
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
@@ -181,7 +181,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 10..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
@@ -191,33 +191,24 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 30.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
   # config.unlock_keys = [:email]
 
-  # Defines which strategy will be used to unlock an account.
-  # :email = Sends an unlock link to the user email
-  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
-  # :both  = Enables both strategies
-  # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :time
 
-  # Number of authentication tries before locking an account if lock_strategy
-  # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 5
 
-  # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
+  config.unlock_in = 1.hour
 
-  # Warn on the last attempt before the account is locked.
-  # config.last_attempt_warning = true
+  config.last_attempt_warning = true
 
   # ==> Configuration for :recoverable
   #

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,7 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc,
+  :password, :password_confirmation, :encrypted_password, :reset_password_token,
+  :unlock_token, :authorization
 ]

--- a/db/migrate/20260313000001_add_lockable_to_users.rb
+++ b/db/migrate/20260313000001_add_lockable_to_users.rb
@@ -1,0 +1,6 @@
+class AddLockableToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :failed_attempts, :integer, default: 0, null: false
+    add_column :users, :locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_13_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_13_000001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -153,6 +153,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_13_000000) do
     t.string "display_name"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.integer "failed_attempts", default: 0, null: false
+    t.datetime "locked_at"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"


### PR DESCRIPTION
## Security Hardening

Based on a comprehensive 5-agent security audit, this PR addresses the critical and high-priority findings.

### Changes

**Authentication Hardening**
- Devise lockable: accounts lock after 5 failed login attempts (auto-unlock after 1 hour)
- Devise timeoutable: sessions expire after 30 minutes of inactivity
- Paranoid mode: prevents user enumeration on login/reset forms
- Minimum password length increased to 10 characters

**SQL Injection Prevention**
- Added `sanitize_sql_like()` to all LIKE query inputs in `ChickenShop` model scopes and API search controller

**Information Leakage**
- Genericized friendship error messages (no longer exposes validation details)
- Validated shareable record existence in messages controller before assignment
- Expanded filtered parameter logging (passwords, tokens, authorization headers)

**Production Hardening**
- Added `Permissions-Policy` header (restricts camera, microphone, geolocation)
- Added `X-Permitted-Cross-Domain-Policies: none` header
- Removed insecure Redis localhost fallback from cable.yml
- Mailer host uses `ENV["APP_HOST"]` with fallback

### Testing
- All 341 tests pass (0 failures, 0 errors)
- RuboCop clean
- Migration adds `failed_attempts` and `locked_at` columns to users table