### PR TITLE
Potential fix for code scanning alert no. 5: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/api/shops_controller.rb
+++ b/app/controllers/api/shops_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class ShopsController < ApplicationController
-    protect_from_forgery with: :null_session
+    skip_before_action :verify_authenticity_token, only: :index
 
     def index
       shops = ChickenShop.left_joins(:reviews)


### PR DESCRIPTION
Potential fix for [https://github.com/lewis-mcgillion/cluckbait/security/code-scanning/5](https://github.com/lewis-mcgillion/cluckbait/security/code-scanning/5)

In general, the problem should be fixed by not globally downgrading CSRF protection to `:null_session`. Instead, rely on the default `protect_from_forgery with: :exception` behavior in `ApplicationController`, and, if necessary for pure-GET JSON endpoints, selectively skip CSRF verification only for safe, idempotent actions that do not change server state.

For this controller, the single best fix without changing observable functionality is:
- Remove the local `protect_from_forgery with: :null_session` override.
- Explicitly skip CSRF verification for the `index` action only, using `skip_before_action :verify_authenticity_token, only: :index`. This keeps strong CSRF protection for any future non-GET actions added to this controller, while allowing the current read-only JSON index to function without an authenticity token.

Concretely, in `app/controllers/api/shops_controller.rb`, replace line 3 (`protect_from_forgery with: :null_session`) with a `skip_before_action` (or `skip_forgery_protection` in newer Rails, but `skip_before_action :verify_authenticity_token` is more broadly compatible). No new imports or other method definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
