### PR TITLE
Potential fix for code scanning alert no. 4: Stored cross-site scripting

### DIFF
--- a/app/views/chicken_shops/show.html.erb
+++ b/app/views/chicken_shops/show.html.erb
@@ -22,8 +22,14 @@
           <% if @chicken_shop.phone.present? %>
             <div class="shop-contact">📞 <%= @chicken_shop.phone %></div>
           <% end %>
-          <% if @chicken_shop.website.present? %>
-            <div class="shop-contact">🌐 <%= link_to "Website", @chicken_shop.website, target: "_blank", rel: "noopener" %></div>
+          <% safe_website_url = begin
+               uri = URI.parse(@chicken_shop.website.to_s)
+               uri.is_a?(URI::HTTP) ? uri.to_s : nil
+             rescue URI::InvalidURIError, TypeError
+               nil
+             end %>
+          <% if safe_website_url.present? %>
+            <div class="shop-contact">🌐 <%= link_to "Website", safe_website_url, target: "_blank", rel: "noopener" %></div>
           <% end %>
         </div>
         <%= render "wishlist_items/wishlist_button", shop: @chicken_shop, wishlist_item: @wishlist_item %>


### PR DESCRIPTION
Potential fix for [https://github.com/lewis-mcgillion/cluckbait/security/code-scanning/4](https://github.com/lewis-mcgillion/cluckbait/security/code-scanning/4)

In general, when using stored values as link URLs, validate and normalize them before passing them to helpers like `link_to`. Only allow safe schemes (typically `http` and `https`), and reject or neutralize anything else so an attacker cannot inject a `javascript:`, `data:`, or other dangerous URL into the page.

The best fix here without changing visible functionality is to wrap `@chicken_shop.website` in a helper that safely parses the URL and only returns it if it uses an allowed scheme; otherwise it returns `nil` (so the link doesn’t render) or a safe default. Since we can only edit this view file, we’ll implement the validation logic inline in Ruby using the standard library `URI` module, which Rails already loads. We’ll compute a `safe_website_url` local variable right before the `link_to` and then use that variable as the link’s `href`. We’ll also guard the link on `safe_website_url.present?` instead of the raw `@chicken_shop.website.present?` so that an unsafe stored URL doesn’t result in a rendered link.

Concretely:
- In `app/views/chicken_shops/show.html.erb`, replace the existing `if @chicken_shop.website.present?` block with:
  - a computation of `safe_website_url` that:
    - attempts `URI.parse(@chicken_shop.website)` inside a `begin/rescue`.
    - checks `uri.is_a?(URI::HTTP)` (which allows both `http` and `https`).
    - assigns `nil` if parsing fails or the scheme is not allowed.
  - an `if safe_website_url.present?` that wraps the `link_to`, using `safe_website_url` as the second argument.
This change uses only Ruby’s standard library and does not alter the link text or styling, only suppresses rendering when the stored URL is unsafe or malformed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
