### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/lewis-mcgillion/cluckbait/security/code-scanning/1](https://github.com/lewis-mcgillion/cluckbait/security/code-scanning/1)

To fix the problem, we should explicitly define minimal `GITHUB_TOKEN` permissions in the workflow. Since all jobs (`test`, `lint`, `security`) only read from the repository (via `actions/checkout`) and do not perform any write operations to GitHub resources, the safest and simplest fix is to add a root-level `permissions:` block with `contents: read`. This applies to all jobs that do not have their own `permissions:` section and does not change any existing behavior for the current steps, because they already work with read access.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert a `permissions:` section after the `name: CI` line and before the `on:` block.
- Set `contents: read` as the only permission, which is sufficient for `actions/checkout@v6` and the rest of the steps.
- No other files, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
