### PR TITLE
Refactor: replace raw SQL with ActiveRecord/Arel expressions

### DIFF
--- a/app/controllers/api/shops_controller.rb
+++ b/app/controllers/api/shops_controller.rb
@@ -4,13 +4,17 @@ module Api
 
     def index
       shops = ChickenShop.left_joins(:reviews)
-                         .select("chicken_shops.*, COALESCE(AVG(reviews.rating), 0) as avg_rating, COUNT(reviews.id) as review_count")
-                         .group("chicken_shops.id")
+                         .select_with_stats
+                         .group(:id)
 
       if params[:search].present?
-        term = ActiveRecord::Base.sanitize_sql_like(params[:search])
-        shops = shops.where("name LIKE ? OR city LIKE ? OR postcode LIKE ?",
-          "%#{term}%", "%#{term}%", "%#{term}%")
+        term = "%#{ActiveRecord::Base.sanitize_sql_like(params[:search])}%"
+        table = ChickenShop.arel_table
+        shops = shops.where(
+          table[:name].matches(term)
+            .or(table[:city].matches(term))
+            .or(table[:postcode].matches(term))
+        )
       end
 
       if params[:lat].present? && params[:lng].present?
@@ -28,8 +32,8 @@ module Api
 
         # Simple distance filter (~30 miles)
         shops = shops.where(
-          "latitude BETWEEN ? AND ? AND longitude BETWEEN ? AND ?",
-          lat - 0.5, lat + 0.5, lng - 0.8, lng + 0.8
+          latitude: (lat - 0.5)..(lat + 0.5),
+          longitude: (lng - 0.8)..(lng + 0.8)
         )
       end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,10 +3,10 @@ class HomeController < ApplicationController
     @chicken_shops = ChickenShop.all
     @recent_reviews = Review.includes(:user, :chicken_shop).recent.limit(6)
     @top_shops = ChickenShop.left_joins(:reviews)
-                            .select("chicken_shops.*, AVG(reviews.rating) as avg_rating, COUNT(reviews.id) as review_count")
-                            .group("chicken_shops.id")
-                            .having("COUNT(reviews.id) > 0")
-                            .order("avg_rating DESC")
+                            .select_with_stats
+                            .group(:id)
+                            .having(ChickenShop.review_count_expr.gt(0))
+                            .order(ChickenShop.avg_rating_expr.desc)
                             .limit(6)
   end
 end

--- a/app/models/chicken_shop.rb
+++ b/app/models/chicken_shop.rb
@@ -10,47 +10,48 @@ class ChickenShop < ApplicationRecord
   validates :longitude, presence: true
   validates :website, format: { with: /\Ahttps?:\/\/\S+\z/i, message: "must start with http:// or https://" }, allow_blank: true
 
-  scope :search_by_name, ->(query) { where("name LIKE ?", "%#{sanitize_sql_like(query)}%") if query.present? }
-  scope :search_by_city, ->(city) { where("city LIKE ?", "%#{sanitize_sql_like(city)}%") if city.present? }
+  scope :search_by_name, ->(query) {
+    where(arel_table[:name].matches("%#{sanitize_sql_like(query)}%")) if query.present?
+  }
+
+  scope :search_by_city, ->(city) {
+    where(arel_table[:city].matches("%#{sanitize_sql_like(city)}%")) if city.present?
+  }
 
   scope :with_min_rating, ->(rating) {
     left_joins(:reviews)
       .group(:id)
-      .having("COALESCE(AVG(reviews.rating), 0) >= ?", rating.to_f)
+      .having(ChickenShop.avg_rating_expr.gteq(rating.to_f))
   }
 
   scope :with_min_reviews, ->(count) {
     left_joins(:reviews)
       .group(:id)
-      .having("COUNT(reviews.id) >= ?", count.to_i)
+      .having(ChickenShop.review_count_expr.gteq(count.to_i))
   }
 
   scope :with_photos, -> {
-    where(
-      "EXISTS (SELECT 1 FROM reviews " \
-      "INNER JOIN active_storage_attachments ON active_storage_attachments.record_type = 'Review' " \
-      "AND active_storage_attachments.record_id = reviews.id " \
-      "AND active_storage_attachments.name = 'photos' " \
-      "WHERE reviews.chicken_shop_id = chicken_shops.id)"
-    )
+    where(id: Review.where(
+      id: ActiveStorage::Attachment.where(record_type: "Review", name: "photos").select(:record_id)
+    ).select(:chicken_shop_id))
   }
 
   scope :in_rating_range, ->(min, max) {
     left_joins(:reviews)
       .group(:id)
-      .having("COALESCE(AVG(reviews.rating), 0) >= ? AND COALESCE(AVG(reviews.rating), 0) <= ?", min.to_f, max.to_f)
+      .having(ChickenShop.avg_rating_expr.gteq(min.to_f).and(ChickenShop.avg_rating_expr.lteq(max.to_f)))
   }
 
   scope :by_highest_rated, -> {
     left_joins(:reviews)
       .group(:id)
-      .order(Arel.sql("COALESCE(AVG(reviews.rating), 0) DESC"))
+      .order(ChickenShop.avg_rating_expr.desc)
   }
 
   scope :by_most_popular, -> {
     left_joins(:reviews)
       .group(:id)
-      .order(Arel.sql("COUNT(reviews.id) DESC"))
+      .order(ChickenShop.review_count_expr.desc)
   }
 
   scope :by_newest, -> { order(created_at: :desc) }
@@ -87,5 +88,24 @@ class ChickenShop < ApplicationRecord
     dlng = (longitude - lng) * rad
     a = Math.sin(dlat / 2)**2 + Math.cos(lat * rad) * Math.cos(latitude * rad) * Math.sin(dlng / 2)**2
     6371 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  end
+
+  def self.avg_rating_expr
+    Arel::Nodes::NamedFunction.new("COALESCE", [
+      Arel::Nodes::NamedFunction.new("AVG", [ Review.arel_table[:rating] ]),
+      Arel::Nodes.build_quoted(0)
+    ])
+  end
+
+  def self.review_count_expr
+    Arel::Nodes::NamedFunction.new("COUNT", [ Review.arel_table[:id] ])
+  end
+
+  def self.select_with_stats
+    select(
+      arel_table[Arel.star],
+      avg_rating_expr.as("avg_rating"),
+      review_count_expr.as("review_count")
+    )
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -26,7 +26,10 @@ class Conversation < ApplicationRecord
   def must_be_friends
     return if sender_id.blank? || receiver_id.blank?
 
-    unless Friendship.accepted.for_user(sender).where("user_id = ? OR friend_id = ?", receiver_id, receiver_id).exists?
+    unless Friendship.accepted
+             .where(user_id: sender_id, friend_id: receiver_id)
+             .or(Friendship.accepted.where(user_id: receiver_id, friend_id: sender_id))
+             .exists?
       errors.add(:base, "You can only message friends")
     end
   end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -16,11 +16,19 @@ class Review < ApplicationRecord
   scope :highest_rated, -> { order(rating: :desc) }
   scope :lowest_rated, -> { order(rating: :asc) }
   scope :by_most_helpful, -> {
+    reactions_table = ReviewReaction.arel_table
+    helpful_case = Arel::Nodes::Case.new
+      .when(reactions_table[:kind].eq("helpful")).then(1)
+      .when(reactions_table[:kind].eq("not_helpful")).then(-1)
+      .else(0)
+    score = Arel::Nodes::NamedFunction.new("COALESCE", [
+      Arel::Nodes::NamedFunction.new("SUM", [ helpful_case ]),
+      Arel::Nodes.build_quoted(0)
+    ])
+
     left_joins(:reactions)
       .group(:id)
-      .order(
-        Arel.sql("COALESCE(SUM(CASE WHEN review_reactions.kind = 'helpful' THEN 1 WHEN review_reactions.kind = 'not_helpful' THEN -1 ELSE 0 END), 0) DESC")
-      )
+      .order(score.desc)
   }
 
   after_create :create_activity


### PR DESCRIPTION
Convert all raw SQL strings across models and controllers to use ActiveRecord query methods and Arel node builders:

- ChickenShop: LIKE queries use arel_table#matches, aggregate having/order use Arel::Nodes::NamedFunction, EXISTS subquery replaced with nested AR where(id:) subqueries. Added reusable avg_rating_expr, review_count_expr, select_with_stats helpers.
- Conversation: OR where clause uses AR where().or(where()) with hash conditions.
- Review: CASE WHEN ordering uses Arel::Nodes::Case.
- Api::ShopsController: uses model helpers, Arel matches with or(), and AR range hash conditions for lat/lng filtering.
- HomeController: uses model Arel helpers for aggregates.

All 435 tests pass.