### PR TITLE
Add pagination to pages with unbounded collections

### DIFF
--- a/app/controllers/chicken_shops_controller.rb
+++ b/app/controllers/chicken_shops_controller.rb
@@ -62,13 +62,20 @@ class ChickenShopsController < ApplicationController
   def show
     @chicken_shop = ChickenShop.find(params[:id])
     @review_sort = params[:review_sort].presence || "recent"
-    @reviews = @chicken_shop.reviews.includes(:user, :reactions)
-    @reviews = case @review_sort
-    when "highest_rated" then @reviews.highest_rated
-    when "lowest_rated" then @reviews.lowest_rated
-    when "most_helpful" then @reviews.by_most_helpful
-    else @reviews.recent
+    reviews = @chicken_shop.reviews.includes(:user, :reactions)
+    reviews = case @review_sort
+    when "highest_rated" then reviews.highest_rated
+    when "lowest_rated" then reviews.lowest_rated
+    when "most_helpful" then reviews.by_most_helpful
+    else reviews.recent
     end
+
+    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @per_page = 25
+    fetched = reviews.limit(@per_page + 1).offset((@page - 1) * @per_page).to_a
+    @has_next_page = fetched.length > @per_page
+    @reviews = @has_next_page ? fetched.first(@per_page) : fetched
+
     @review = Review.new
     @user_review = current_user ? @chicken_shop.reviews.find_by(user: current_user) : nil
     @wishlist_item = current_user ? current_user.wishlist_items.find_by(chicken_shop: @chicken_shop) : nil

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -2,7 +2,12 @@ class ConversationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @conversations = current_user.conversations.ordered.includes(:sender, :receiver, :messages)
+    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @per_page = 25
+    fetched = current_user.conversations.ordered.includes(:sender, :receiver, :messages)
+                .limit(@per_page + 1).offset((@page - 1) * @per_page).to_a
+    @has_next_page = fetched.length > @per_page
+    @conversations = @has_next_page ? fetched.first(@per_page) : fetched
   end
 
   def show

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -5,6 +5,12 @@ class FriendshipsController < ApplicationController
     @friends = current_user.friends
     @pending_requests = current_user.pending_friend_requests.includes(:user)
     @sent_requests = current_user.sent_friendships.pending.includes(:friend)
+
+    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @per_page = 25
+    fetched = @friends.limit(@per_page + 1).offset((@page - 1) * @per_page).to_a
+    @has_next_page = fetched.length > @per_page
+    @friends = @has_next_page ? fetched.first(@per_page) : fetched
   end
 
   def create

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,7 +2,12 @@ class NotificationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @notifications = current_user.notifications.recent_first.includes(:actor, :notifiable).limit(50)
+    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @per_page = 25
+    fetched = current_user.notifications.recent_first.includes(:actor, :notifiable)
+                .limit(@per_page + 1).offset((@page - 1) * @per_page).to_a
+    @has_next_page = fetched.length > @per_page
+    @notifications = @has_next_page ? fetched.first(@per_page) : fetched
   end
 
   def mark_as_read

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,6 +5,12 @@ class ProfilesController < ApplicationController
   def show
     @reviews = @user.reviews.includes(:chicken_shop).recent
     @wishlist_items = @user.wishlist_items.includes(:chicken_shop).want_to_try.recent
+
+    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @per_page = 25
+    fetched_reviews = @reviews.limit(@per_page + 1).offset((@page - 1) * @per_page).to_a
+    @has_next_page = fetched_reviews.length > @per_page
+    @reviews = @has_next_page ? fetched_reviews.first(@per_page) : fetched_reviews
   end
 
   def edit

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -14,6 +14,12 @@ class ReviewsController < ApplicationController
     else
       @reviews = @chicken_shop.reviews.includes(:user).recent
       @user_review = nil
+      @page = 1
+      @per_page = 25
+      fetched = @reviews.limit(@per_page + 1).offset(0).to_a
+      @has_next_page = fetched.length > @per_page
+      @reviews = @has_next_page ? fetched.first(@per_page) : fetched
+      @wishlist_item = current_user ? current_user.wishlist_items.find_by(chicken_shop: @chicken_shop) : nil
       flash.now[:alert] = @review.errors.full_messages.join(", ")
       render "chicken_shops/show", status: :unprocessable_entity
     end

--- a/app/controllers/wishlist_items_controller.rb
+++ b/app/controllers/wishlist_items_controller.rb
@@ -10,6 +10,12 @@ class WishlistItemsController < ApplicationController
     when "visited" then @wishlist_items.visited
     else @wishlist_items
     end
+
+    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @per_page = 25
+    fetched = @wishlist_items.limit(@per_page + 1).offset((@page - 1) * @per_page).to_a
+    @has_next_page = fetched.length > @per_page
+    @wishlist_items = @has_next_page ? fetched.first(@per_page) : fetched
   end
 
   def create

--- a/app/views/chicken_shops/index.html.erb
+++ b/app/views/chicken_shops/index.html.erb
@@ -185,24 +185,7 @@
         <% end %>
       </div>
 
-      <% if @page > 1 || @has_next_page %>
-        <nav class="pagination" aria-label="Pages">
-          <% base_params = request.query_parameters.except("page") %>
-          <% if @page > 1 %>
-            <%= link_to "← Previous", chicken_shops_path(base_params.merge(page: @page - 1)), class: "pagination-btn" %>
-          <% else %>
-            <span class="pagination-btn pagination-btn--disabled">← Previous</span>
-          <% end %>
-
-          <span class="pagination-info">Page <%= @page %></span>
-
-          <% if @has_next_page %>
-            <%= link_to "Next →", chicken_shops_path(base_params.merge(page: @page + 1)), class: "pagination-btn" %>
-          <% else %>
-            <span class="pagination-btn pagination-btn--disabled">Next →</span>
-          <% end %>
-        </nav>
-      <% end %>
+      <%= render "shared/pagination" %>
     <% else %>
       <div class="empty-state">
         <span class="empty-icon">🔍</span>

--- a/app/views/chicken_shops/show.html.erb
+++ b/app/views/chicken_shops/show.html.erb
@@ -123,7 +123,7 @@
       <!-- Right column: Reviews -->
       <div class="shop-reviews">
         <div class="reviews-header">
-          <h2 class="reviews-heading">Reviews (<%= @reviews.count %>)</h2>
+          <h2 class="reviews-heading">Reviews (<%= @chicken_shop.reviews_count %>)</h2>
           <div class="review-sort-options" data-controller="search-filter">
             <span class="sort-label">Sort:</span>
             <% [["recent", "🕐 Recent"], ["highest_rated", "⭐ Highest"], ["lowest_rated", "👎 Lowest"], ["most_helpful", "👍 Most Helpful"]].each do |value, label| %>
@@ -140,6 +140,7 @@
             <% @reviews.each do |review| %>
               <%= render "reviews/review_card", review: review, chicken_shop: @chicken_shop %>
             <% end %>
+            <%= render "shared/pagination" %>
           <% else %>
             <div class="empty-state">
               <span class="empty-icon">📝</span>

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -40,6 +40,7 @@
           <% end %>
         <% end %>
       </div>
+      <%= render "shared/pagination" %>
     <% else %>
       <div class="empty-state">
         <span class="empty-icon">💬</span>

--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -92,6 +92,7 @@
             </div>
           <% end %>
         </div>
+        <%= render "shared/pagination" %>
       <% else %>
         <div class="empty-state">
           <span class="empty-icon">🤝</span>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -14,6 +14,7 @@
         <% @notifications.each do |notification| %>
           <%= render partial: "notification", locals: { notification: notification } %>
         <% end %>
+        <%= render "shared/pagination" %>
       <% else %>
         <div class="empty-state">
           <span class="empty-icon">🔔</span>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -87,6 +87,7 @@
           </div>
         <% end %>
       </div>
+      <%= render "shared/pagination" %>
     <% else %>
       <div class="empty-state">
         <span class="empty-icon">🍗</span>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,0 +1,18 @@
+<% if @page > 1 || @has_next_page %>
+  <nav class="pagination" aria-label="Pages">
+    <% base_params = request.query_parameters.except("page") %>
+    <% if @page > 1 %>
+      <%= link_to "← Previous", url_for(base_params.merge(page: @page - 1)), class: "pagination-btn" %>
+    <% else %>
+      <span class="pagination-btn pagination-btn--disabled">← Previous</span>
+    <% end %>
+
+    <span class="pagination-info">Page <%= @page %></span>
+
+    <% if @has_next_page %>
+      <%= link_to "Next →", url_for(base_params.merge(page: @page + 1)), class: "pagination-btn" %>
+    <% else %>
+      <span class="pagination-btn pagination-btn--disabled">Next →</span>
+    <% end %>
+  </nav>
+<% end %>

--- a/app/views/wishlist_items/index.html.erb
+++ b/app/views/wishlist_items/index.html.erb
@@ -62,6 +62,7 @@
           </div>
         <% end %>
       </div>
+      <%= render "shared/pagination" %>
     <% else %>
       <div class="empty-state">
         <span class="empty-icon">🔖</span>

--- a/test/controllers/pagination_test.rb
+++ b/test/controllers/pagination_test.rb
@@ -1,0 +1,214 @@
+require "test_helper"
+
+class PaginationTest < ActionDispatch::IntegrationTest
+  # -- Chicken Shops Index --
+
+  test "chicken shops index paginates results" do
+    30.times { create(:chicken_shop) }
+
+    get chicken_shops_path
+    assert_response :success
+    assert_select ".pagination"
+    assert_select ".pagination-btn", text: "Next →"
+  end
+
+  test "chicken shops index page 2 shows previous button" do
+    30.times { create(:chicken_shop) }
+
+    get chicken_shops_path, params: { page: 2 }
+    assert_response :success
+    assert_select ".pagination-btn", text: "← Previous"
+  end
+
+  test "chicken shops index no pagination when few results" do
+    3.times { create(:chicken_shop) }
+
+    get chicken_shops_path
+    assert_response :success
+    assert_select ".pagination", count: 0
+  end
+
+  # -- Chicken Shop Reviews --
+
+  test "shop show paginates reviews" do
+    shop = create(:chicken_shop)
+    30.times { create(:review, chicken_shop: shop) }
+
+    get chicken_shop_path(shop)
+    assert_response :success
+    assert_select ".pagination"
+  end
+
+  test "shop show no pagination when few reviews" do
+    shop = create(:chicken_shop)
+    3.times { create(:review, chicken_shop: shop) }
+
+    get chicken_shop_path(shop)
+    assert_response :success
+    assert_select ".pagination", count: 0
+  end
+
+  test "shop show page 2 reviews" do
+    shop = create(:chicken_shop)
+    30.times { create(:review, chicken_shop: shop) }
+
+    get chicken_shop_path(shop), params: { page: 2 }
+    assert_response :success
+    assert_select ".pagination-btn", text: "← Previous"
+  end
+
+  test "shop show preserves review sort across pages" do
+    shop = create(:chicken_shop)
+    30.times { create(:review, chicken_shop: shop) }
+
+    get chicken_shop_path(shop), params: { review_sort: "highest_rated", page: 1 }
+    assert_response :success
+  end
+
+  # -- Profile Reviews --
+
+  test "profile paginates reviews" do
+    user = create(:user)
+    30.times { create(:review, user: user) }
+
+    get profile_path(user)
+    assert_response :success
+    assert_select ".pagination"
+  end
+
+  test "profile no pagination when few reviews" do
+    user = create(:user)
+    3.times { create(:review, user: user) }
+
+    get profile_path(user)
+    assert_response :success
+    assert_select ".pagination", count: 0
+  end
+
+  # -- Wishlist --
+
+  test "wishlist paginates items" do
+    user = create(:user)
+    sign_in user
+    30.times { create(:wishlist_item, user: user) }
+
+    get wishlist_items_path
+    assert_response :success
+    assert_select ".pagination"
+  end
+
+  test "wishlist no pagination when few items" do
+    user = create(:user)
+    sign_in user
+    3.times { create(:wishlist_item, user: user) }
+
+    get wishlist_items_path
+    assert_response :success
+    assert_select ".pagination", count: 0
+  end
+
+  test "wishlist preserves filter across pages" do
+    user = create(:user)
+    sign_in user
+    30.times { create(:wishlist_item, user: user, visited: false) }
+
+    get wishlist_items_path, params: { filter: "want_to_try", page: 1 }
+    assert_response :success
+  end
+
+  # -- Notifications --
+
+  test "notifications paginates results" do
+    user = create(:user)
+    sign_in user
+    30.times { create(:notification, user: user) }
+
+    get notifications_path
+    assert_response :success
+    assert_select ".pagination"
+  end
+
+  test "notifications no pagination when few results" do
+    user = create(:user)
+    sign_in user
+    3.times { create(:notification, user: user) }
+
+    get notifications_path
+    assert_response :success
+    assert_select ".pagination", count: 0
+  end
+
+  # -- Conversations --
+
+  test "conversations paginates results" do
+    user = create(:user)
+    sign_in user
+    30.times do
+      friend = create(:user)
+      create(:friendship, :accepted, user: user, friend: friend)
+      create(:conversation, sender: user, receiver: friend)
+    end
+
+    get conversations_path
+    assert_response :success
+    assert_select ".pagination"
+  end
+
+  test "conversations no pagination when few results" do
+    user = create(:user)
+    sign_in user
+    friend = create(:user)
+    create(:friendship, :accepted, user: user, friend: friend)
+    create(:conversation, sender: user, receiver: friend)
+
+    get conversations_path
+    assert_response :success
+    assert_select ".pagination", count: 0
+  end
+
+  # -- Friends --
+
+  test "friends paginates results" do
+    user = create(:user)
+    sign_in user
+    30.times do
+      friend = create(:user)
+      create(:friendship, :accepted, user: user, friend: friend)
+    end
+
+    get friendships_path
+    assert_response :success
+    assert_select ".pagination"
+  end
+
+  test "friends no pagination when few results" do
+    user = create(:user)
+    sign_in user
+    2.times do
+      friend = create(:user)
+      create(:friendship, :accepted, user: user, friend: friend)
+    end
+
+    get friendships_path
+    assert_response :success
+    assert_select ".pagination", count: 0
+  end
+
+  # -- Edge cases --
+
+  test "page param below 1 defaults to page 1" do
+    get chicken_shops_path, params: { page: -5 }
+    assert_response :success
+  end
+
+  test "page param beyond results shows empty page" do
+    3.times { create(:chicken_shop) }
+    get chicken_shops_path, params: { page: 999 }
+    assert_response :success
+  end
+
+  test "non-numeric page param defaults to page 1" do
+    get chicken_shops_path, params: { page: "abc" }
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Pages now paginated (25 per page):
- Chicken shop reviews (show page)
- Profile reviews
- Wishlist items
- Notifications (replaces hard limit of 50)
- Conversations list
- Friends list

Also:
- Extract shared _pagination partial (DRYs up all pagination views)
- Fix ReviewsController#create to set pagination vars when re-rendering show
- Add 21 pagination tests covering all pages and edge cases