### PR TITLE
Fix critical bugs: mobile nav, CSP rating bars, sign-out GET

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -159,6 +159,30 @@ img { max-width: 100%; height: auto; display: block; }
 .nav-username { color: var(--text-primary); font-weight: 500; font-size: 0.9rem; }
 .nav-signout { font-size: 0.8rem; }
 
+/* Hamburger button — hidden on desktop */
+.nav-hamburger {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
+  z-index: 1001;
+}
+.hamburger-line {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: var(--text-primary);
+  border-radius: 2px;
+  transition: all 0.3s ease;
+}
+.nav-hamburger.active .hamburger-line:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+.nav-hamburger.active .hamburger-line:nth-child(2) { opacity: 0; }
+.nav-hamburger.active .hamburger-line:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+
 /* ===== Flash Messages ===== */
 .flash {
   display: flex; align-items: center; justify-content: space-between;
@@ -638,7 +662,23 @@ img { max-width: 100%; height: auto; display: block; }
 
 /* ===== Responsive ===== */
 @media (max-width: 768px) {
-  .nav-center { display: none; }
+  .nav-hamburger { display: flex; }
+  .nav-center {
+    display: none;
+    position: absolute;
+    top: 64px;
+    left: 0;
+    right: 0;
+    background: rgba(15, 15, 15, 0.95);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--border);
+    flex-direction: column;
+    padding: 1rem;
+    gap: 0.25rem;
+    z-index: 999;
+  }
+  .nav-center--open { display: flex; }
+  .nav-center .nav-link { width: 100%; padding: 0.75rem 1rem; border-radius: var(--radius-sm); }
   .nav-username { display: none; }
   .hero { padding: 3rem 1rem 1.5rem; }
   .hero-title { font-size: 1.75rem; }

--- a/app/javascript/controllers/mobile_nav_controller.js
+++ b/app/javascript/controllers/mobile_nav_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu"]
+
+  toggle() {
+    const button = this.element.querySelector(".nav-hamburger")
+    const expanded = button.getAttribute("aria-expanded") === "true"
+
+    button.setAttribute("aria-expanded", !expanded)
+    button.classList.toggle("active")
+    this.menuTarget.classList.toggle("nav-center--open")
+  }
+
+  // Close menu when clicking a nav link
+  close() {
+    const button = this.element.querySelector(".nav-hamburger")
+    button.setAttribute("aria-expanded", "false")
+    button.classList.remove("active")
+    this.menuTarget.classList.remove("nav-center--open")
+  }
+}

--- a/app/javascript/controllers/rating_bars_controller.js
+++ b/app/javascript/controllers/rating_bars_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Sets the width of rating bar fills from data-width attributes
+// to avoid CSP inline style violations.
+export default class extends Controller {
+  connect() {
+    this.element.querySelectorAll("[data-width]").forEach((el) => {
+      el.style.width = `${el.dataset.width}%`
+    })
+  }
+}

--- a/app/views/chicken_shops/show.html.erb
+++ b/app/views/chicken_shops/show.html.erb
@@ -53,12 +53,12 @@
         <!-- Rating Distribution -->
         <div class="sidebar-card">
           <h3>Rating Breakdown</h3>
-          <div class="rating-bars">
+          <div class="rating-bars" data-controller="rating-bars">
             <% @chicken_shop.rating_distribution.reverse_each do |rating, count| %>
               <div class="rating-bar-row">
                 <span class="rating-bar-label"><%= rating %> ★</span>
                 <div class="rating-bar-track">
-                  <div class="rating-bar-fill" style="width: <%= @chicken_shop.reviews_count > 0 ? (count.to_f / @chicken_shop.reviews_count * 100).round : 0 %>%"></div>
+                  <div class="rating-bar-fill" data-width="<%= @chicken_shop.reviews_count > 0 ? (count.to_f / @chicken_shop.reviews_count * 100).round : 0 %>"></div>
                 </div>
                 <span class="rating-bar-count"><%= count %></span>
               </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar">
+<nav class="navbar" data-controller="mobile-nav">
   <div class="nav-container">
     <div class="nav-left">
       <%= link_to root_path, class: "nav-logo" do %>
@@ -7,7 +7,13 @@
       <% end %>
     </div>
 
-    <div class="nav-center">
+    <button class="nav-hamburger" data-action="click->mobile-nav#toggle" aria-label="Toggle navigation menu" aria-expanded="false">
+      <span class="hamburger-line"></span>
+      <span class="hamburger-line"></span>
+      <span class="hamburger-line"></span>
+    </button>
+
+    <div class="nav-center" data-mobile-nav-target="menu">
       <%= link_to "Discover", root_path, class: "nav-link #{'active' if current_page?(root_path)}" %>
       <% if user_signed_in? %>
         <%= link_to "Feed", activities_path, class: "nav-link #{'active' if current_page?(activities_path)}" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,8 +34,10 @@ Rails.application.routes.draw do
     end
   end
 
-  # API endpoints for map
   get "api/shops", to: "api/shops#index"
+
+  # Fallback for sign-out via GET (when JS/Turbo is unavailable)
+  get "users/sign_out", to: redirect("/")
 
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
1. Mobile navigation: Add hamburger menu for screens ≤768px with Stimulus controller. Previously nav-center was hidden with no alternative, locking mobile users out of all features.

2. CSP inline styles: Replace bare inline style="width: X%" on rating breakdown bars with data-width attributes + Stimulus controller (rating_bars_controller). Fixes CSP violations that caused all bars to render at 100% width.

3. Sign-out GET 404: Add GET /users/sign_out fallback route that redirects to root. Previously returned 404 when JS/Turbo was unavailable.