### PR TITLE
Fix major bugs: auth, accessibility, 404 page, message validation

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -351,7 +351,7 @@ img { max-width: 100%; height: auto; display: block; }
 }
 .shop-card-location { font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 0.5rem; }
 .shop-card-stats { display: flex; justify-content: space-between; align-items: center; }
-.shop-reviews-count { font-size: 0.8rem; color: var(--text-muted); }
+.shop-reviews-count { font-size: 0.8rem; color: var(--text-secondary); }
 .shop-card-stars { color: var(--accent); font-size: 0.85rem; letter-spacing: 1px; }
 
 /* ===== Filter Bar ===== */

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,6 @@ class ApplicationController < ActionController::Base
   private
 
   def record_not_found
-    render file: Rails.public_path.join("404.html"), status: :not_found, layout: false
+    render "errors/not_found", status: :not_found
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,13 @@
+module Users
+  class PasswordsController < Devise::PasswordsController
+    def create
+      if params.dig(:user, :email).blank?
+        self.resource = resource_class.new
+        resource.errors.add(:email, :blank)
+        respond_with(resource)
+      else
+        super
+      end
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,8 +2,16 @@ module Users
   class RegistrationsController < Devise::RegistrationsController
     protected
 
+    def after_sign_up_path_for(_resource)
+      root_path
+    end
+
     def update_resource(resource, params)
-      resource.update_without_password(params)
+      if params[:password].present? || (params[:email].present? && params[:email] != resource.email)
+        resource.update_with_password(params)
+      else
+        resource.update_without_password(params.except(:current_password))
+      end
     end
 
     private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,8 +5,7 @@ class Message < ApplicationRecord
 
   ALLOWED_SHAREABLE_TYPES = %w[ChickenShop Review].freeze
 
-  validates :body, presence: true, length: { maximum: 2000 }, unless: :shareable_present?
-  validates :body, length: { maximum: 2000 }, if: :shareable_present?
+  validates :body, presence: true, length: { maximum: 2000 }
   validates :shareable_type, inclusion: { in: ALLOWED_SHAREABLE_TYPES }, allow_nil: true
   validate :user_is_participant
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
   has_many :conversation_reads, dependent: :destroy
   has_many :notifications, dependent: :destroy
 
-  validates :display_name, length: { maximum: 50 }
+  validates :display_name, presence: true, length: { maximum: 50 }
   validates :bio, length: { maximum: 500 }
 
   def name

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,7 +5,7 @@
     <h1 class="devise-title">Join Cluckbait 🍗</h1>
     <p class="devise-subtitle">Create your free account and start reviewing</p>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "auth-form" }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "auth-form", data: { turbo: false } }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="form-group">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,7 +5,7 @@
     <h1 class="devise-title">Welcome back 🍗</h1>
     <p class="devise-subtitle">Sign in to your Cluckbait account</p>
 
-    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "auth-form" }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "auth-form", data: { turbo: false } }) do |f| %>
       <div class="form-group">
         <%= f.label :email, class: "form-label" %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-input", placeholder: "you@example.com" %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,11 @@
+<% content_for(:title) { "Page Not Found — Cluckbait" } %>
+
+<div class="empty-state" style="padding: 4rem 1rem;">
+  <span class="empty-icon">🍗</span>
+  <h1>404 — Page Not Found</h1>
+  <p>Looks like this chicken has flown the coop! The page you're looking for doesn't exist.</p>
+  <div style="margin-top: 1.5rem; display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
+    <%= link_to "Go Home", root_path, class: "btn btn-primary" %>
+    <%= link_to "Browse Shops", chicken_shops_path, class: "btn btn-outline" %>
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -20,6 +20,7 @@
                  data-action="input->map#search"
                  placeholder="Search by name, city, or postcode..."
                  class="search-input"
+                 aria-label="Search by name, city, or postcode"
                  autocomplete="off">
           <button data-action="click->map#locate"
                   class="btn btn-accent btn-locate"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title><%= content_for(:title) || "Cluckbait" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -54,7 +54,7 @@
             <% end %>
             <span class="nav-username"><%= current_user.name %></span>
           <% end %>
-          <%= link_to "Sign out", destroy_user_session_path, data: { turbo_method: :delete }, class: "nav-link nav-signout" %>
+          <%= link_to "Sign out", destroy_user_session_path, data: { turbo_method: :delete, turbo: false }, class: "nav-link nav-signout" %>
         </div>
       <% else %>
         <%= link_to "Sign in", new_user_session_path, class: "nav-link" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: "users/registrations"
+    registrations: "users/registrations",
+    passwords: "users/passwords"
   }
 
   root "home#index"

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -62,9 +62,9 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to conversation_path(@conversation)
   end
 
-  test "create with shareable and no body succeeds" do
+  test "create with shareable and no body fails" do
     shop = create(:chicken_shop)
-    assert_difference "Message.count", 1 do
+    assert_no_difference "Message.count" do
       post conversation_messages_path(@conversation), params: {
         message: { body: "", shareable_type: "ChickenShop", shareable_id: shop.id }
       }, as: :turbo_stream

--- a/test/controllers/users/registrations_controller_test.rb
+++ b/test/controllers/users/registrations_controller_test.rb
@@ -19,8 +19,8 @@ class Users::RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "ChickenLover", user.display_name
   end
 
-  test "sign up without display_name creates user" do
-    assert_difference "User.count", 1 do
+  test "sign up without display_name fails" do
+    assert_no_difference "User.count" do
       post user_registration_path, params: {
         user: {
           email: "noname@example.com",
@@ -29,7 +29,7 @@ class Users::RegistrationsControllerTest < ActionDispatch::IntegrationTest
         }
       }
     end
-    assert_redirected_to root_path
+    assert_response :unprocessable_entity
   end
 
   test "sign up with invalid email fails" do
@@ -91,13 +91,28 @@ class Users::RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "New bio", user.bio
   end
 
-  test "update email without requiring current password" do
-    user = create(:user, email: "old@example.com")
+  test "update email requires current password" do
+    user = create(:user, email: "old@example.com", password: "password123")
     sign_in user
 
     put user_registration_path, params: {
       user: {
         email: "new@example.com"
+      }
+    }
+
+    user.reload
+    assert_equal "old@example.com", user.email
+  end
+
+  test "update email succeeds with current password" do
+    user = create(:user, email: "old@example.com", password: "password123")
+    sign_in user
+
+    put user_registration_path, params: {
+      user: {
+        email: "new@example.com",
+        current_password: "password123"
       }
     }
 

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -92,7 +92,8 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
       user: {
         email: "flowtest@example.com",
         password: "password123",
-        password_confirmation: "password123"
+        password_confirmation: "password123",
+        display_name: "FlowTester"
       }
     }
     assert_redirected_to root_path

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -13,10 +13,10 @@ class MessageTest < ActiveSupport::TestCase
     assert message.valid?
   end
 
-  test "valid message with shareable and no body" do
+  test "message with shareable requires body" do
     shop = create(:chicken_shop)
     message = build(:message, conversation: @conversation, user: @sender, body: nil, shareable: shop)
-    assert message.valid?
+    assert_not message.valid?
   end
 
   test "invalid without body and without shareable" do
@@ -62,13 +62,13 @@ class MessageTest < ActiveSupport::TestCase
 
   test "valid shareable_type ChickenShop" do
     shop = create(:chicken_shop)
-    message = build(:message, conversation: @conversation, user: @sender, shareable: shop, body: nil)
+    message = build(:message, conversation: @conversation, user: @sender, shareable: shop, body: "Check this out!")
     assert message.valid?
   end
 
   test "valid shareable_type Review" do
     review = create(:review)
-    message = build(:message, conversation: @conversation, user: @sender, shareable: review, body: nil)
+    message = build(:message, conversation: @conversation, user: @sender, shareable: review, body: "Check this out!")
     assert message.valid?
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -46,8 +46,8 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user.errors[:email], "has already been taken"
   end
 
-  test "display_name can be blank" do
-    assert build(:user, display_name: "").valid?
+  test "display_name must be present" do
+    assert_not build(:user, display_name: "").valid?
   end
 
   test "display_name cannot exceed 50 characters" do


### PR DESCRIPTION
1. Post-sign-up redirect: Override after_sign_up_path_for to return root_path instead of redirecting to a random shop page.

2. Turbo nav caching: Add data-turbo=false to sign-in, sign-up, and sign-out forms/links to force full page reload, ensuring navbar re-renders with correct auth state.

3. Profile update security: Require current_password when changing email or password. Non-sensitive fields (display_name, bio) can still be updated without password.

4. Forgot password empty email: Add custom PasswordsController that validates email presence before delegating to Devise paranoid mode.

5. Display name presence: Add presence validation to display_name to prevent email prefix leaking as fallback name.

6. HTML lang attribute: Add lang="en" to <html> tag for screen readers.

7. Search input label: Add aria-label to homepage search input for accessibility (WCAG Level A).

8. Color contrast: Change .shop-reviews-count from --text-muted to --text-secondary for WCAG AA compliance.

9. Styled 404 page: Replace static public/404.html with dynamic errors/not_found view rendered within app layout with navigation.

10. Message body validation: Always require body text, even when a shareable item is attached.