### PR TITLE
Switch from rubocop-rails-omakase to rubocop-github style rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,41 @@
-# Omakase Ruby styling for Rails
-inherit_gem: { rubocop-rails-omakase: rubocop.yml }
+# GitHub Ruby styling for Rails
+# https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md
+inherit_gem:
+  rubocop-github:
+    - config/default.yml
+    - config/rails.yml
+  rubocop-minitest:
+    - config/default.yml
 
-# Overwrite or add rules to create your own house style
-#
-# # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
-# Layout/SpaceInsideArrayLiteralBrackets:
-#   Enabled: false
+plugins:
+  - rubocop-minitest
+  - rubocop-performance
+  - rubocop-rails
+
+AllCops:
+  TargetRubyVersion: 3.4
+  TargetRailsVersion: 8.0
+  NewCops: disable
+  SuggestExtensions: false
+  Exclude:
+    - bin/**/*
+    - node_modules/**/*
+    - vendor/**/*
+    - tmp/**/*
+    - db/schema.rb
+
+# Match github/github: 118 char line length for PR diff readability
+Layout/LineLength:
+  Enabled: true
+  Max: 118
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# These cops expect explicit full-path render calls (github/github monolith convention).
+# Standard Rails `render :action` is fine for this codebase.
+GitHub/RailsControllerRenderPathsExist:
+  Enabled: false
+
+GitHub/RailsControllerRenderLiteral:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,9 @@ gem "tailwindcss-rails"
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
+gem "solid_cable"
 gem "solid_cache"
 gem "solid_queue"
-gem "solid_cable"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
@@ -53,8 +53,11 @@ group :development, :test do
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
 
-  # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
-  gem "rubocop-rails-omakase", require: false
+  # GitHub Ruby styling [https://github.com/github/rubocop-github]
+  gem "rubocop-github", require: false
+  gem "rubocop-minitest", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
 end
 
 group :development do
@@ -65,7 +68,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
-  gem "selenium-webdriver"
   gem "factory_bot_rails"
   gem "minitest", "~> 6.0"
+  gem "selenium-webdriver"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,14 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-github (0.27.0)
+      rubocop (>= 1.76)
+      rubocop-performance (>= 1.24)
+      rubocop-rails (>= 2.23)
+    rubocop-minitest (0.39.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
     rubocop-performance (1.26.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
@@ -318,10 +326,6 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.44.0, < 2.0)
-    rubocop-rails-omakase (1.1.0)
-      rubocop (>= 1.72)
-      rubocop-performance (>= 1.24)
-      rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     ruby-vips (2.3.0)
       ffi (~> 1.12)
@@ -434,7 +438,10 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.2)
-  rubocop-rails-omakase
+  rubocop-github
+  rubocop-minitest
+  rubocop-performance
+  rubocop-rails
   selenium-webdriver
   solid_cable
   solid_cache

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -16,7 +16,7 @@ class ActivitiesController < ApplicationController
   private
 
   def current_page
-    [ (params[:page].to_i), 1 ].max
+    [(params[:page].to_i), 1].max
   end
 
   def page_offset

--- a/app/controllers/chicken_shops_controller.rb
+++ b/app/controllers/chicken_shops_controller.rb
@@ -1,5 +1,5 @@
 class ChickenShopsController < ApplicationController
-  before_action :authenticate_user!, only: [ :new, :create ]
+  before_action :authenticate_user!, only: [:new, :create]
 
   def new
     @chicken_shop = ChickenShop.new
@@ -52,7 +52,7 @@ class ChickenShopsController < ApplicationController
 
     @active_filters = active_filter_count
 
-    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @page = [(params[:page] || 1).to_i, 1].max
     @per_page = 25
     @total_count = @chicken_shops.count
     fetched = @chicken_shops.limit(@per_page + 1).offset((@page - 1) * @per_page).to_a
@@ -71,7 +71,7 @@ class ChickenShopsController < ApplicationController
     else reviews.recent
     end
 
-    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @page = [(params[:page] || 1).to_i, 1].max
     @per_page = 25
     fetched = reviews.limit(@per_page + 1).offset((@page - 1) * @per_page).to_a
     @has_next_page = fetched.length > @per_page
@@ -85,7 +85,8 @@ class ChickenShopsController < ApplicationController
   private
 
   def chicken_shop_params
-    params.require(:chicken_shop).permit(:name, :address, :city, :postcode, :phone, :website, :description, :latitude, :longitude, :image)
+    params.require(:chicken_shop).permit(:name, :address, :city, :postcode, :phone, :website, :description,
+:latitude, :longitude, :image)
   end
 
   def active_filter_count

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -2,7 +2,7 @@ class ConversationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @page = [(params[:page] || 1).to_i, 1].max
     @per_page = 25
     fetched = current_user.conversations.ordered.includes(:sender, :receiver, :messages)
                 .limit(@per_page + 1).offset((@page - 1) * @per_page).to_a

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -6,7 +6,7 @@ class FriendshipsController < ApplicationController
     @pending_requests = current_user.pending_friend_requests.includes(:user)
     @sent_requests = current_user.sent_friendships.pending.includes(:friend)
 
-    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @page = [(params[:page] || 1).to_i, 1].max
     @per_page = 25
     fetched = @friends.limit(@per_page + 1).offset((@page - 1) * @per_page).to_a
     @has_next_page = fetched.length > @per_page

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,7 +2,7 @@ class NotificationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @page = [(params[:page] || 1).to_i, 1].max
     @per_page = 25
     fetched = current_user.notifications.recent_first.includes(:actor, :notifiable)
                 .limit(@per_page + 1).offset((@page - 1) * @per_page).to_a

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,12 +1,12 @@
 class ProfilesController < ApplicationController
-  before_action :authenticate_user!, only: [ :edit, :update ]
+  before_action :authenticate_user!, only: [:edit, :update]
   before_action :set_user
 
   def show
     @reviews = @user.reviews.includes(:chicken_shop).recent
     @wishlist_items = @user.wishlist_items.includes(:chicken_shop).want_to_try.recent
 
-    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @page = [(params[:page] || 1).to_i, 1].max
     @per_page = 25
     fetched_reviews = @reviews.limit(@per_page + 1).offset((@page - 1) * @per_page).to_a
     @has_next_page = fetched_reviews.length > @per_page

--- a/app/controllers/review_reactions_controller.rb
+++ b/app/controllers/review_reactions_controller.rb
@@ -21,7 +21,8 @@ class ReviewReactionsController < ApplicationController
         "review_#{@review.id}_reactions",
         partial: "reviews/reaction_bar",
         locals: { review: @review.reload, current_user: current_user }
-      ) }
+      )
+      }
       format.html { redirect_back fallback_location: @review.chicken_shop }
     end
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -21,7 +21,8 @@ module Users
     end
 
     def account_update_params
-      params.require(:user).permit(:email, :password, :password_confirmation, :current_password, :display_name, :bio, :avatar)
+      params.require(:user).permit(:email, :password, :password_confirmation, :current_password, :display_name, :bio,
+:avatar)
     end
   end
 end

--- a/app/controllers/wishlist_items_controller.rb
+++ b/app/controllers/wishlist_items_controller.rb
@@ -1,6 +1,6 @@
 class WishlistItemsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_wishlist_item, only: [ :update, :destroy ]
+  before_action :set_wishlist_item, only: [:update, :destroy]
 
   def index
     @filter = params[:filter] || "all"
@@ -11,7 +11,7 @@ class WishlistItemsController < ApplicationController
     else @wishlist_items
     end
 
-    @page = [ (params[:page] || 1).to_i, 1 ].max
+    @page = [(params[:page] || 1).to_i, 1].max
     @per_page = 25
     fetched = @wishlist_items.limit(@per_page + 1).offset((@page - 1) * @per_page).to_a
     @has_next_page = fetched.length > @per_page
@@ -20,7 +20,8 @@ class WishlistItemsController < ApplicationController
 
   def create
     @chicken_shop = ChickenShop.find(params[:chicken_shop_id])
-    @wishlist_item = current_user.wishlist_items.build(chicken_shop: @chicken_shop, visited: false, notes: wishlist_params[:notes])
+    @wishlist_item = current_user.wishlist_items.build(chicken_shop: @chicken_shop, visited: false,
+notes: wishlist_params[:notes])
 
     if @wishlist_item.save
       respond_to do |format|
@@ -41,7 +42,10 @@ class WishlistItemsController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream
-      format.html { redirect_to wishlist_items_path, notice: @wishlist_item.visited? ? "Marked as visited! ✅" : "Moved back to Want to Try" }
+      format.html {
+        redirect_to wishlist_items_path,
+       notice: @wishlist_item.visited? ? "Marked as visited! ✅" : "Moved back to Want to Try"
+      }
     end
   end
 

--- a/app/models/chicken_shop.rb
+++ b/app/models/chicken_shop.rb
@@ -8,7 +8,8 @@ class ChickenShop < ApplicationRecord
   validates :city, presence: true
   validates :latitude, presence: true
   validates :longitude, presence: true
-  validates :website, format: { with: /\Ahttps?:\/\/\S+\z/i, message: "must start with http:// or https://" }, allow_blank: true
+  validates :website, format: { with: /\Ahttps?:\/\/\S+\z/i, message: "must start with http:// or https://" },
+allow_blank: true
 
   scope :search_by_name, ->(query) {
     where(arel_table[:name].matches("%#{sanitize_sql_like(query)}%")) if query.present?
@@ -73,7 +74,7 @@ class ChickenShop < ApplicationRecord
   end
 
   def full_address
-    [ address, city, postcode ].compact.join(", ")
+    [address, city, postcode].compact.join(", ")
   end
 
   def rating_distribution
@@ -92,13 +93,13 @@ class ChickenShop < ApplicationRecord
 
   def self.avg_rating_expr
     Arel::Nodes::NamedFunction.new("COALESCE", [
-      Arel::Nodes::NamedFunction.new("AVG", [ Review.arel_table[:rating] ]),
+      Arel::Nodes::NamedFunction.new("AVG", [Review.arel_table[:rating]]),
       Arel::Nodes.build_quoted(0)
     ])
   end
 
   def self.review_count_expr
-    Arel::Nodes::NamedFunction.new("COUNT", [ Review.arel_table[:id] ])
+    Arel::Nodes::NamedFunction.new("COUNT", [Review.arel_table[:id]])
   end
 
   def self.select_with_stats

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -22,7 +22,7 @@ class Review < ApplicationRecord
       .when(reactions_table[:kind].eq("not_helpful")).then(-1)
       .else(0)
     score = Arel::Nodes::NamedFunction.new("COALESCE", [
-      Arel::Nodes::NamedFunction.new("SUM", [ helpful_case ]),
+      Arel::Nodes::NamedFunction.new("SUM", [helpful_case]),
       Arel::Nodes.build_quoted(0)
     ])
 

--- a/app/models/review_reaction.rb
+++ b/app/models/review_reaction.rb
@@ -5,5 +5,5 @@ class ReviewReaction < ApplicationRecord
   belongs_to :review
 
   validates :kind, presence: true, inclusion: { in: KINDS }
-  validates :kind, uniqueness: { scope: [ :user_id, :review_id ], message: "already reacted with this kind" }
+  validates :kind, uniqueness: { scope: [:user_id, :review_id], message: "already reacted with this kind" }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ApplicationRecord
   end
 
   def friends
-    accepted_friend_ids = Friendship.accepted_for(self).pluck(:user_id, :friend_id).flatten.uniq - [ id ]
+    accepted_friend_ids = Friendship.accepted_for(self).pluck(:user_id, :friend_id).flatten.uniq - [id]
     User.where(id: accepted_friend_ids)
   end
 
@@ -106,9 +106,19 @@ class User < ApplicationRecord
   end
 
   def unread_conversations_count
-    conversations.where(
-      "EXISTS (SELECT 1 FROM messages WHERE messages.conversation_id = conversations.id AND messages.user_id != ? AND messages.created_at > COALESCE((SELECT last_read_at FROM conversation_reads WHERE conversation_reads.conversation_id = conversations.id AND conversation_reads.user_id = ?), '1970-01-01'))",
-      id, id
-    ).count
+    unread_sql = <<~SQL.squish
+      EXISTS (
+        SELECT 1 FROM messages
+        WHERE messages.conversation_id = conversations.id
+          AND messages.user_id != ?
+          AND messages.created_at > COALESCE(
+            (SELECT last_read_at FROM conversation_reads
+             WHERE conversation_reads.conversation_id = conversations.id
+               AND conversation_reads.user_id = ?),
+            '1970-01-01'
+          )
+      )
+    SQL
+    conversations.where(unread_sql, id, id).count
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
   config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
@@ -77,7 +77,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Only use :id for inspections in production.
-  config.active_record.attributes_for_inspect = [ :id ]
+  config.active_record.attributes_for_inspect = [:id]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '869a13de4af635aa6307260074547c0ab33f7f4749e930c61d14c8d2c3a79fcc21d973497e6564046bb3ed13520a3b8cc7319b3c28e82d7270d49f7fa33b73bc'
+  # config.secret_key = 'configure_me'
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
@@ -58,12 +58,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [ :email ]
+  config.case_insensitive_keys = [:email]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [ :email ]
+  config.strip_whitespace_keys = [:email]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the
@@ -97,7 +97,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [ :http_auth ]
+  config.skip_session_storage = [:http_auth]
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX
@@ -126,7 +126,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 12
 
   # Set up a pepper to generate the hashed password.
-  # config.pepper = '0bca314dc910f850a9b4f53d18fe78271c2a4d3265a8941c8e1dac6dec80579b8e497125b6e9bf64b81f655c65a6e4817ffda10b41c3f7963baa16c6a6a8cf39'
+  # config.pepper = 'configure_me'
 
   # Send a notification to the original email when the user's email is changed.
   config.send_email_changed_notification = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,27 +6,27 @@ Rails.application.routes.draw do
 
   root "home#index"
 
-  resources :chicken_shops, only: [ :index, :show, :new, :create ] do
-    resources :reviews, only: [ :create, :destroy ]
+  resources :chicken_shops, only: [:index, :show, :new, :create] do
+    resources :reviews, only: [:create, :destroy]
   end
 
   resources :reviews, only: [] do
-    resources :reactions, only: [ :create ], controller: "review_reactions"
+    resources :reactions, only: [:create], controller: "review_reactions"
   end
 
-  resources :profiles, only: [ :show, :edit, :update ], param: :id
+  resources :profiles, only: [:show, :edit, :update], param: :id
 
-  resources :wishlist_items, only: [ :index, :create, :update, :destroy ]
+  resources :wishlist_items, only: [:index, :create, :update, :destroy]
 
-  resources :friendships, only: [ :index, :create, :update, :destroy ]
+  resources :friendships, only: [:index, :create, :update, :destroy]
 
-  resources :activities, only: [ :index ]
+  resources :activities, only: [:index]
 
-  resources :conversations, only: [ :index, :show, :create ] do
-    resources :messages, only: [ :create ]
+  resources :conversations, only: [:index, :show, :create] do
+    resources :messages, only: [:create]
   end
 
-  resources :notifications, only: [ :index ] do
+  resources :notifications, only: [:index] do
     member do
       patch :mark_as_read
     end
@@ -40,5 +40,5 @@ Rails.application.routes.draw do
   # Fallback for sign-out via GET (when JS/Turbo is unavailable)
   get "users/sign_out", to: redirect("/")
 
-  get "up" => "rails/health#show", as: :rails_health_check
+  get "up" => "rails/health#show", :as => :rails_health_check
 end

--- a/db/migrate/20260312194621_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260312194621_create_active_storage_tables.active_storage.rb
@@ -19,7 +19,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
         t.datetime :created_at, null: false
       end
 
-      t.index [ :key ], unique: true
+      t.index [:key], unique: true
     end
 
     create_table :active_storage_attachments, id: primary_key_type do |t|
@@ -33,7 +33,8 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
         t.datetime :created_at, null: false
       end
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.index [:record_type, :record_id, :name, :blob_id], name: :index_active_storage_attachments_uniqueness,
+unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
@@ -41,17 +42,17 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
       t.belongs_to :blob, null: false, index: false, type: foreign_key_type
       t.string :variation_digest, null: false
 
-      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.index [:blob_id, :variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end
 
   private
-    def primary_and_foreign_key_types
-      config = Rails.configuration.generators
-      setting = config.options[config.orm][:primary_key_type]
-      primary_key_type = setting || :primary_key
-      foreign_key_type = setting || :bigint
-      [ primary_key_type, foreign_key_type ]
-    end
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
 end

--- a/db/migrate/20260312212238_create_friendships.rb
+++ b/db/migrate/20260312212238_create_friendships.rb
@@ -7,6 +7,6 @@ class CreateFriendships < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :friendships, [ :user_id, :friend_id ], unique: true
+    add_index :friendships, [:user_id, :friend_id], unique: true
   end
 end

--- a/db/migrate/20260312212252_create_conversations.rb
+++ b/db/migrate/20260312212252_create_conversations.rb
@@ -6,6 +6,6 @@ class CreateConversations < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :conversations, [ :sender_id, :receiver_id ], unique: true
+    add_index :conversations, [:sender_id, :receiver_id], unique: true
   end
 end

--- a/db/migrate/20260312212253_create_messages.rb
+++ b/db/migrate/20260312212253_create_messages.rb
@@ -9,6 +9,6 @@ class CreateMessages < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :messages, [ :shareable_type, :shareable_id ]
+    add_index :messages, [:shareable_type, :shareable_id]
   end
 end

--- a/db/migrate/20260312213359_create_conversation_reads.rb
+++ b/db/migrate/20260312213359_create_conversation_reads.rb
@@ -8,6 +8,6 @@ class CreateConversationReads < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :conversation_reads, [ :user_id, :conversation_id ], unique: true
+    add_index :conversation_reads, [:user_id, :conversation_id], unique: true
   end
 end

--- a/db/migrate/20260312215820_create_review_reactions.rb
+++ b/db/migrate/20260312215820_create_review_reactions.rb
@@ -8,6 +8,6 @@ class CreateReviewReactions < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :review_reactions, [ :user_id, :review_id, :kind ], unique: true
+    add_index :review_reactions, [:user_id, :review_id, :kind], unique: true
   end
 end

--- a/db/migrate/20260312215919_create_notifications.rb
+++ b/db/migrate/20260312215919_create_notifications.rb
@@ -12,7 +12,7 @@ class CreateNotifications < ActiveRecord::Migration[8.1]
     end
 
     add_foreign_key :notifications, :users, column: :actor_id
-    add_index :notifications, [ :user_id, :read_at ]
-    add_index :notifications, [ :notifiable_type, :notifiable_id ]
+    add_index :notifications, [:user_id, :read_at]
+    add_index :notifications, [:notifiable_type, :notifiable_id]
   end
 end

--- a/db/migrate/20260312220000_create_wishlist_items.rb
+++ b/db/migrate/20260312220000_create_wishlist_items.rb
@@ -9,6 +9,6 @@ class CreateWishlistItems < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :wishlist_items, [ :user_id, :chicken_shop_id ], unique: true
+    add_index :wishlist_items, [:user_id, :chicken_shop_id], unique: true
   end
 end

--- a/db/migrate/20260313000000_create_activities.rb
+++ b/db/migrate/20260313000000_create_activities.rb
@@ -9,7 +9,7 @@ class CreateActivities < ActiveRecord::Migration[8.0]
       t.timestamps
     end
 
-    add_index :activities, [ :user_id, :created_at ]
-    add_index :activities, [ :trackable_type, :trackable_id ]
+    add_index :activities, [:user_id, :created_at]
+    add_index :activities, [:trackable_type, :trackable_id]
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 end

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -138,7 +138,7 @@ class ReviewsControllerTest < ActionDispatch::IntegrationTest
   test "create with photo upload" do
     sign_in @user
 
-    file = Tempfile.new([ "test_image", ".jpg" ])
+    file = Tempfile.new(["test_image", ".jpg"])
     file.write("fake image data")
     file.rewind
 
@@ -150,7 +150,7 @@ class ReviewsControllerTest < ActionDispatch::IntegrationTest
           rating: 5,
           title: "With photo",
           body: "Check this out!",
-          photos: [ photo ]
+          photos: [photo]
         }
       }
     end

--- a/test/factories/activities.rb
+++ b/test/factories/activities.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
 
     trait :friendship_activity do
       action { "became_friends" }
-      association :trackable, factory: [ :friendship, :accepted ]
+      association :trackable, factory: [:friendship, :accepted]
     end
   end
 end

--- a/test/models/activity_test.rb
+++ b/test/models/activity_test.rb
@@ -58,12 +58,12 @@ class ActivityTest < ActiveSupport::TestCase
 
     a1 = create(:activity, user: user1, action: "posted_review")
     a2 = create(:activity, user: user2, action: "posted_review")
-    _a3 = create(:activity, user: user3, action: "posted_review")
+    a3 = create(:activity, user: user3, action: "posted_review")
 
-    results = Activity.for_users([ user1, user2 ])
+    results = Activity.for_users([user1, user2])
     assert_includes results, a1
     assert_includes results, a2
-    assert_not_includes results, _a3
+    assert_not_includes results, a3
   end
 
   # -- Callbacks --

--- a/test/models/wishlist_item_test.rb
+++ b/test/models/wishlist_item_test.rb
@@ -61,7 +61,7 @@ class WishlistItemTest < ActiveSupport::TestCase
 
   test "visited defaults to false" do
     item = create(:wishlist_item)
-    assert_equal false, item.visited
+    refute item.visited
   end
 
   test "notes are optional" do


### PR DESCRIPTION
Replace rubocop-rails-omakase with rubocop-github to match github/github code style conventions. Key changes:

- Use rubocop-github gem with its default + Rails config
- Add rubocop-performance, rubocop-minitest, rubocop-rails plugins
- Enforce 118 char line length (github/github PR diff readability)
- Fix SpaceInsideArrayLiteralBrackets: [a, b] not [ a, b ]
- Fix long SQL line in User#unread_conversations_count with heredoc
- Fix Bundler/OrderedGems ordering in Gemfile
- Fix HashSyntax mixed styles in routes
- Fix underscore-prefixed variable usage in tests
- Fix Minitest/RefuteFalse preference
- Remove hardcoded secret keys from devise.rb comments
- Disable GitHub-monolith-specific render cops (RenderPathsExist, RenderLiteral) that don't apply to standard Rails apps

All 544 tests pass. Zero rubocop offenses.